### PR TITLE
add a parameter to set a user domain

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -7,6 +7,7 @@ airlock {
     ranger {
         allow-list-buckets = ${?ALLOW_LIST_BUCKETS}
         allow-create-buckets = ${?ALLOW_CREATE_BUCKETS}
+        user-domain-postfix = ${?AIRLOCK_RANGER_USER_DOMAIN_POSTFIX}
     }
     storage.s3 {
         # Settings for reaching backing storage.

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -14,6 +14,7 @@ airlock {
         app_id = "testservice"
         allow-list-buckets = false
         allow-create-buckets = false
+        user-domain-postfix = ""
     }
 
     storage.s3 {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/config/RangerSettings.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/config/RangerSettings.scala
@@ -6,8 +6,9 @@ import com.typesafe.config.Config
 class RangerSettings(config: Config) extends Extension {
   val serviceType: String = config.getString("airlock.ranger.service_type")
   val appId: String = config.getString("airlock.ranger.app_id")
-  val listBucketsEnabled = config.getBoolean("airlock.ranger.allow-list-buckets")
-  val createBucketsEnabled = config.getBoolean("airlock.ranger.allow-create-buckets")
+  val listBucketsEnabled: Boolean = config.getBoolean("airlock.ranger.allow-list-buckets")
+  val createBucketsEnabled: Boolean = config.getBoolean("airlock.ranger.allow-create-buckets")
+  val userDomainPostfix: String = config.getString("airlock.ranger.user-domain-postfix")
 }
 
 object RangerSettings extends ExtensionId[RangerSettings] with ExtensionIdProvider {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -51,7 +51,7 @@ trait AuthorizationProviderRanger extends LazyLogging {
       val rangerRequest = new RangerAccessRequestImpl(
         rangerResource,
         request.accessType.rangerName,
-        user.userName.value,
+        user.userName.value + rangerSettings.userDomainPostfix,
         user.userAssumedGroup.map(_.value).toSet[String].asJava
       )
 


### PR DESCRIPTION
if the AIRLOCK_RANGER_USER_DOMAIN_POSTFIX is set this postfix is added to the user name when send to ranger.