### PR TITLE
Improve atlas lineage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     - "8080:8080"
 
   atlas:
-    image: nielsdenissen/airlock-dev-apache-atlas:0.0.3
+    image: nielsdenissen/airlock-dev-apache-atlas:0.0.4
     ports:
     - "21000:21000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     - "8080:8080"
 
   atlas:
-    image: nielsdenissen/airlock-dev-apache-atlas:0.0.2
+    image: nielsdenissen/airlock-dev-apache-atlas:0.0.3
     ports:
     - "21000:21000"
 

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlasItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlasItTest.scala
@@ -47,10 +47,11 @@ class LineageProviderAtlasItTest extends AsyncWordSpec with DiagrammedAssertions
         fakeIncomingHttpRequest(HttpMethods.PUT, "/fakeBucket/fakeObject"), userSTS)
 
       createLineageResult.map { result =>
-            assert( result.serverGuid.length > 0 )
-            assert( result.bucketGuid.length > 0 )
-            assert( result.fileGuid.length > 0 )
-            assert( result.processGuid.length > 0 )
+          val postResult = result.asInstanceOf[LineagePostGuidResponse]
+            assert( postResult.serverGuid.length > 0 )
+            assert( postResult.bucketGuid.length > 0 )
+            assert( postResult.fileGuid.length > 0 )
+            assert( postResult.processGuid.length > 0 )
         }
     }
 
@@ -60,10 +61,11 @@ class LineageProviderAtlasItTest extends AsyncWordSpec with DiagrammedAssertions
         fakeIncomingHttpRequest(HttpMethods.GET, "/fakeBucket/fakeObject"), userSTS)
 
       createLineageResult.map { result =>
-            assert( result.serverGuid.length > 0 )
-            assert( result.bucketGuid.length > 0 )
-            assert( result.fileGuid.length > 0 )
-            assert( result.processGuid.length > 0 )
+        val postResult = result.asInstanceOf[LineagePostGuidResponse]
+            assert( postResult.serverGuid.length > 0 )
+            assert( postResult.bucketGuid.length > 0 )
+            assert( postResult.fileGuid.length > 0 )
+            assert( postResult.processGuid.length > 0 )
         }
     }
 
@@ -73,10 +75,8 @@ class LineageProviderAtlasItTest extends AsyncWordSpec with DiagrammedAssertions
         fakeIncomingHttpRequest(HttpMethods.DELETE, "/fakeBucket/fakeObject"), userSTS)
 
       createLineageResult.map { result =>
-            assert( result.serverGuid.length == 0 )
-            assert( result.bucketGuid.length == 0 )
-            assert( result.fileGuid.length > 0 )
-            assert( result.processGuid.length == 0 )
+        val postResult = result.asInstanceOf[LineageGuidResponse]
+            assert( postResult.entityGUID.length > 0 )
       }
     }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
@@ -35,7 +35,7 @@ trait ProxyService extends LazyLogging {
 
   // Atlas Lineage
   protected[this] def atlasSettings: AtlasSettings
-  protected[this] def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User): Future[LineagePostGuidResponse]
+  protected[this] def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User): Future[LineageResponse]
 
   val proxyServiceRoute: Route =
     withoutSizeLimit {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageGuidResponse.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageGuidResponse.scala
@@ -1,3 +1,0 @@
-package com.ing.wbaa.airlock.proxy.data
-
-case class LineageGuidResponse(entityGUID: String)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageGuidResponse.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageGuidResponse.scala
@@ -1,0 +1,3 @@
+package com.ing.wbaa.airlock.proxy.data
+
+case class LineageGuidResponse(entityGUID: String)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageHeaders.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageHeaders.scala
@@ -1,0 +1,11 @@
+package com.ing.wbaa.airlock.proxy.data
+
+import akka.http.scaladsl.model.{ ContentType, HttpMethod }
+
+case class LineageHeaders(
+    host: String,
+    bucket: String,
+    bucketObject: String,
+    method: HttpMethod,
+    contentType: ContentType,
+    clientType: String)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageHeaders.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageHeaders.scala
@@ -3,9 +3,11 @@ package com.ing.wbaa.airlock.proxy.data
 import akka.http.scaladsl.model.{ ContentType, HttpMethod }
 
 case class LineageHeaders(
-    host: String,
+    host: Option[String],
     bucket: String,
     bucketObject: String,
     method: HttpMethod,
     contentType: ContentType,
-    clientType: String)
+    clientType: String,
+    queryParams: Option[String],
+    copySource: Option[String])

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineagePostGuidResponse.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineagePostGuidResponse.scala
@@ -1,7 +1,0 @@
-package com.ing.wbaa.airlock.proxy.data
-
-case class LineagePostGuidResponse(
-    serverGuid: String,
-    bucketGuid: String,
-    fileGuid: String,
-    processGuid: String)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageResponse.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/LineageResponse.scala
@@ -1,0 +1,11 @@
+package com.ing.wbaa.airlock.proxy.data
+
+sealed trait LineageResponse
+
+case class LineageGuidResponse(entityGUID: String) extends LineageResponse
+
+case class LineagePostGuidResponse(
+    serverGuid: String,
+    bucketGuid: String,
+    fileGuid: String,
+    processGuid: String) extends LineageResponse

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -26,12 +26,12 @@ trait LineageProviderAtlas extends LazyLogging with RestClient with LineageHelpe
     val host = lh.host.getOrElse("unknown")
 
     def readOrWriteLineage(method: String, bucket: String): Future[LineagePostGuidResponse] = {
-      logger.debug(s"Creating $method lineage for request to ${lh.method.value} file ${lh.bucketObject} to $bucket at $timestamp")
+      logger.debug(s"Creating $method lineage for request to ${lh.method.value} file ${lh.bucketObject} at $bucket at $timestamp")
       postEnities(userName, host, bucket, lh.bucketObject, method, lh.contentType, lh.clientType, timestamp)
     }
 
     def delLineage(method: String): Future[LineageGuidResponse] = {
-      logger.debug(s"Creating Delete lineage for request to ${lh.method} file ${lh.bucketObject} to ${lh.bucket} at $timestamp")
+      logger.debug(s"Creating Delete lineage for request to ${lh.method} file ${lh.bucketObject} at ${lh.bucket} at $timestamp")
       deleteEntities("DataFile", lh.bucketObject)
     }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -16,7 +16,6 @@ trait LineageProviderAtlas extends LazyLogging with RestClient with LineageHelpe
   protected[this] implicit def system: ActorSystem
   protected[this] implicit def executionContext: ExecutionContext
   protected[this] implicit def materializer: Materializer
-
   protected[this] implicit def atlasSettings: AtlasSettings
 
   def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User): Future[LineageResponse] = {
@@ -70,7 +69,10 @@ trait LineageProviderAtlas extends LazyLogging with RestClient with LineageHelpe
     }
   }
 }
+
 object LineageProviderAtlas {
+
   final case class LineageProviderAtlasException(private val message: String, private val cause: Throwable = None.orNull)
     extends Exception(message, cause)
+
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -75,6 +75,8 @@ trait LineageProviderAtlas extends LazyLogging with RestClient {
         List(guidRef(outputGuid, outputType))))))
   }
 
+
+  // move to LineageHelpers and split to postEntity
   private def postEnities(userSTS: String, host: String, bucket: String, bucketObject: String, method: String, contentType: ContentType, timestamp: Long): Future[LineagePostGuidResponse] = {
     for {
       serverGuid <- postData(serverEntities(userSTS, host).toJson)
@@ -108,6 +110,16 @@ trait LineageProviderAtlas extends LazyLogging with RestClient {
       _ <- deleteEntity(entityGuid)
 
     } yield LineagePostGuidResponse("", "", entityGuid, "")
+
+  // bucket name as partitioning
+
+  // for all filter only on wanted subresource
+  // get object
+  // put object
+  // put object - copy
+  // post object (complete multipart)
+  // delete on abort multipart
+  // delete object
 
   def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User): Future[LineagePostGuidResponse] = {
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -1,18 +1,17 @@
 package com.ing.wbaa.airlock.proxy.provider
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.{ ContentType, HttpMethods, HttpRequest }
+import akka.http.scaladsl.model.{ HttpMethods, HttpRequest }
 import akka.stream.Materializer
 import com.ing.wbaa.airlock.proxy.config.AtlasSettings
 import com.ing.wbaa.airlock.proxy.data._
 import com.ing.wbaa.airlock.proxy.provider.LineageProviderAtlas.LineageProviderAtlasException
-import com.ing.wbaa.airlock.proxy.provider.atlas.Model.{ Bucket, BucketAttributes, Classification, Entities, FileAttributes, IngestedFile, Ingestion, IngestionAttributes, Server, ServerAttributes, guidRef }
-import com.ing.wbaa.airlock.proxy.provider.atlas.RestClient
+import com.ing.wbaa.airlock.proxy.provider.atlas.{ LineageHelpers, RestClient }
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait LineageProviderAtlas extends LazyLogging with RestClient {
+trait LineageProviderAtlas extends LazyLogging with RestClient with LineageHelpers {
 
   protected[this] implicit def system: ActorSystem
   protected[this] implicit def executionContext: ExecutionContext
@@ -20,131 +19,35 @@ trait LineageProviderAtlas extends LazyLogging with RestClient {
 
   protected[this] implicit def atlasSettings: AtlasSettings
 
-  private def serverEntities(userSTS: String, host: String) =
-    Entities(Seq(Server(
-      "Server",
-      userSTS,
-      ServerAttributes(host, host, host, host),
-      Seq(Classification("staging_node")))))
-
-  private def bucketEntities(userSTS: String, bucket: String) =
-    Entities(Seq(Bucket(
-      "Bucket",
-      userSTS,
-      BucketAttributes(bucket, bucket, bucket),
-      Seq(Classification("customer_PII")))))
-
-  private def fileEntities(
-      serverGuid: String,
-      bucketGuid: String,
-      bucketObject: String,
-      userSTS: String,
-      inputGuid: String,
-      inputType: String,
-      outputGuid: String,
-      outputType: String,
-      contentType: ContentType) = {
-    Entities(Seq(IngestedFile(
-      "DataFile",
-      userSTS,
-      FileAttributes(bucketObject, bucketObject, bucketObject, contentType.mediaType.value,
-        guidRef(bucketGuid, "Bucket"),
-        List(guidRef(inputGuid, inputType)),
-        List(guidRef(outputGuid, outputType)),
-        Seq(Classification("customer_PII"))))))
-  }
-
-  private def processEntities(
-      serverGuid: String,
-      bucketGuid: String,
-      fileGuid: String,
-      userSTS: String,
-      method: String,
-      inputGuid: String,
-      inputType: String,
-      outputGuid: String,
-      outputType: String,
-      timestamp: Long) = {
-    Entities(Seq(Ingestion(
-      "aws_cli_script",
-      userSTS,
-      IngestionAttributes(s"aws_cli_${timestamp}", s"aws_cli_${timestamp}", method, userSTS,
-        guidRef(serverGuid, "Server"),
-        List(guidRef(inputGuid, inputType)),
-        List(guidRef(outputGuid, outputType))))))
-  }
-
-
-  // move to LineageHelpers and split to postEntity
-  private def postEnities(userSTS: String, host: String, bucket: String, bucketObject: String, method: String, contentType: ContentType, timestamp: Long): Future[LineagePostGuidResponse] = {
-    for {
-      serverGuid <- postData(serverEntities(userSTS, host).toJson)
-      bucketGuid <- postData(bucketEntities(userSTS, bucket).toJson)
-      fileGuid <- method match {
-        case access if access == "read" =>
-          postData(
-            fileEntities(serverGuid, bucketGuid, bucketObject, userSTS, bucketGuid, "Bucket", serverGuid, "Server", contentType).toJson)
-        case access if access == "write" =>
-          postData(
-            fileEntities(serverGuid, bucketGuid, bucketObject, userSTS, serverGuid, "Server", bucketGuid, "Bucket", contentType).toJson)
-      }
-      processGuid <- method match {
-        case access if access == "read" =>
-          postData(
-            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, bucketGuid, "Bucket", fileGuid, "DataFile", timestamp).toJson)
-        case access if access == "write" =>
-          postData(
-            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, fileGuid, "DataFile", bucketGuid, "Bucket", timestamp).toJson)
-      }
-    } yield LineagePostGuidResponse(serverGuid, bucketGuid, fileGuid, processGuid)
-  }
-
-  // file entity delete
-  // for now it is just deleting file entity and no related objects like eg. aws_cli_script, which uploaded or downloaded
-  // file to bucket. Once we delete aws_cli_script object we will lose track of whats has been deleted
-  // We need to come up with process of tracking file delete
-  private def deleteEntities(typeName: String, entityName: String): Future[LineagePostGuidResponse] =
-    for {
-      entityGuid <- getEntityGUID(typeName, entityName)
-      _ <- deleteEntity(entityGuid)
-
-    } yield LineagePostGuidResponse("", "", entityGuid, "")
-
-  // bucket name as partitioning
-
   // for all filter only on wanted subresource
-  // get object
-  // put object
+
   // put object - copy
   // post object (complete multipart)
   // delete on abort multipart
-  // delete object
 
   def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User): Future[LineagePostGuidResponse] = {
 
     val timestamp = System.currentTimeMillis()
-    // createLineageFromRequest is used in RequestHandlerS3 where there is no notion of S3Request. It seems easier to
-    // repeat httpRequest parsing here for needed values
-    val host = httpRequest.uri.authority.host.address()
-    val path = httpRequest.uri.path
-    val bucket = path.toString.split("/").toList.lift(1).getOrElse("notDef")
-    val bucketObject = s"${path.toString.split("/").toList.lift(2).getOrElse("emptyObject")}"
-    val method = httpRequest.method
-    val contentType = httpRequest.entity.contentType
     val userName = userSTS.userName.value
+    val lh = getLineageHeaders(httpRequest)
 
-    if (bucket != "notDef" && bucketObject != "emptyObject") {
-      logger.debug(s"Creating lineage for request ${method.value} file ${bucketObject} in ${bucket} at ${timestamp}")
-      method match {
-        case HttpMethods.GET | HttpMethods.HEAD =>
-          logger.debug(s"Creating Read lineage for request to ${method.value} file ${bucketObject} to ${bucket} at ${timestamp}")
-          postEnities(userName, host, bucket, bucketObject, "read", contentType, timestamp)
+    if (lh.bucket.length > 1 && lh.bucketObject != "emptyObject") {
+      logger.debug(s"Creating lineage for request ${lh.method.value} file ${lh.bucketObject} in ${lh.bucket} at ${timestamp}")
+      lh.method match {
+        // get object
+        case HttpMethods.GET =>
+          logger.debug(s"Creating Read lineage for request to ${lh.method.value} file ${lh.bucketObject} to ${lh.bucket} at ${timestamp}")
+          postEnities(userName, lh.host, lh.bucket, lh.bucketObject, "read", lh.contentType, lh.clientType, timestamp)
+
+        // put object
         case HttpMethods.POST | HttpMethods.PUT =>
-          logger.debug(s"Creating Write lineage for request to ${method.value} file ${bucketObject} to ${bucket} at ${timestamp}")
-          postEnities(userName, host, bucket, bucketObject, "write", contentType, timestamp)
+          logger.debug(s"Creating Write lineage for request to ${lh.method.value} file ${lh.bucketObject} to ${lh.bucket} at ${timestamp}")
+          postEnities(userName, lh.host, lh.bucket, lh.bucketObject, "write", lh.contentType, lh.clientType, timestamp)
+
+        // delete object
         case HttpMethods.DELETE =>
-          logger.debug(s"Creating Delete lineage for request to ${method} file ${bucketObject} to ${bucket} at ${timestamp}")
-          deleteEntities("DataFile", bucketObject)
+          logger.debug(s"Creating Delete lineage for request to ${lh.method} file ${lh.bucketObject} to ${lh.bucket} at ${timestamp}")
+          deleteEntities("DataFile", lh.bucketObject)
         case _ => Future.failed(LineageProviderAtlasException("Create lineage failed"))
       }
     } else {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -49,7 +49,6 @@ trait LineageProviderAtlas extends LazyLogging with RestClient {
       userSTS,
       FileAttributes(bucketObject, bucketObject, bucketObject, contentType.mediaType.value,
         guidRef(bucketGuid, "Bucket"),
-        guidRef(serverGuid, "Server"),
         List(guidRef(inputGuid, inputType)),
         List(guidRef(outputGuid, outputType)),
         Seq(Classification("customer_PII"))))))

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -1,7 +1,7 @@
 package com.ing.wbaa.airlock.proxy.provider.atlas
 
 import akka.http.scaladsl.model.{ContentType, HttpRequest}
-import com.ing.wbaa.airlock.proxy.data.{LineageHeaders, LineagePostGuidResponse}
+import com.ing.wbaa.airlock.proxy.data.{LineageGuidResponse, LineageHeaders, LineagePostGuidResponse}
 import com.ing.wbaa.airlock.proxy.provider.atlas.Model._
 import com.typesafe.scalalogging.LazyLogging
 
@@ -9,21 +9,21 @@ import scala.concurrent.Future
 
 trait LineageHelpers extends LazyLogging with RestClient {
 
-  def serverEntities(userSTS: String, host: String, classification: String) =
+  private def serverEntities(userSTS: String, host: String, classification: String) =
     Entities(Seq(Server(
       "Server",
       userSTS,
       ServerAttributes(host, host, host, host),
       Seq(Classification(classification)))))
 
-  def bucketEntities(userSTS: String, bucket: String, classification: String) =
+  private def bucketEntities(userSTS: String, bucket: String, classification: String) =
     Entities(Seq(Bucket(
       "Bucket",
       userSTS,
       BucketAttributes(bucket, bucket, bucket),
       Seq(Classification(classification)))))
 
-  def fileEntities(
+  private def fileEntities(
                     bucketGuid: String,
                     bucketObject: String,
                     userSTS: String,
@@ -37,7 +37,7 @@ trait LineageHelpers extends LazyLogging with RestClient {
         Seq(Classification(classification))))))
   }
 
-  def processEntities(
+  private def processEntities(
                        serverGuid: String,
                        bucketGuid: String,
                        fileGuid: String,
@@ -45,57 +45,55 @@ trait LineageHelpers extends LazyLogging with RestClient {
                        method: String,
                        inputs: List[guidRef],
                        outputs: List[guidRef],
+                       clientType: String,
                        timestamp: Long) = {
     Entities(Seq(Ingestion(
       "airlock_client",
       userSTS,
-      IngestionAttributes(s"aws_cli_${timestamp}", s"aws_cli_${timestamp}", method, userSTS,
+      IngestionAttributes(s"${clientType}_$timestamp", s"${clientType}_$timestamp", method, userSTS,
         guidRef(serverGuid, "Server"),
         inputs,
         outputs))))
   }
 
-  private def extractClient(userAgent: String) =
+  private def extractClient(userAgent: String): String =
     """(\S+)/\S+""".r
       .findFirstMatchIn(userAgent)
       .map(_ group 1).getOrElse("")
 
+  private def extractHeaderOption(httpRequest: HttpRequest, header: String): Option[String] =
+    if (httpRequest.getHeader(header).isPresent)
+      Some(httpRequest.getHeader(header).get().value())
+    else
+      None
+
   // createLineageFromRequest is used in RequestHandlerS3 where there is no notion of S3Request. It seems easier to
   // repeat httpRequest parsing here for needed values
   def getLineageHeaders(httpRequest: HttpRequest): LineageHeaders = {
-    val host = httpRequest.getHeader("Remote-Address").get().value() // make option
+    val host = extractHeaderOption(httpRequest, "Remote-Address")
     val path = httpRequest.uri.path.toString().split("/")
     val bucket = path.take(path.length - 1).mkString("/")
     val bucketObject = path.lastOption.getOrElse("emptyObject")
     val method = httpRequest.method
     val contentType = httpRequest.entity.contentType
-    val clientType = extractClient(httpRequest.getHeader("User-Agent").get().value()) // make option
+    val clientType =  extractClient(extractHeaderOption(httpRequest, "User-Agent").getOrElse("generic"))
+    val queryParams = httpRequest.uri.rawQueryString
+    val copySource = extractHeaderOption(httpRequest, "x-amz-copy-source")
 
-    LineageHeaders(host, bucket, bucketObject, method, contentType, clientType)
+    LineageHeaders(host, bucket, bucketObject, method, contentType, clientType, queryParams, copySource)
   }
-
-  def splitQueryToJavaMap(queryString: String): Map[String, List[String]] =
-    queryString.split("&").map { paramAndValue =>
-      paramAndValue.split("=")
-        .grouped(2)
-        .map {
-          case Array(k, v) => (k, List(v))
-          case Array(k)    => (k, List(""))
-        }
-    }.toList.flatten.toMap
 
   // file entity delete
   // for now it is just deleting file entity and no related objects like eg. aws_cli_script, which uploaded or downloaded
   // file to bucket. Once we delete aws_cli_script object we will lose track of whats has been deleted
   // We need to come up with process of tracking file delete
-  def deleteEntities(typeName: String, entityName: String): Future[LineagePostGuidResponse] =
+  def deleteEntities(typeName: String, entityName: String): Future[LineageGuidResponse] =
     for {
       entityGuid <- getEntityGUID(typeName, entityName)
       _ <- deleteEntity(entityGuid)
 
-    } yield LineagePostGuidResponse("", "", entityGuid, "")
+    } yield LineageGuidResponse(entityGuid)
 
-  // move to LineageHelpers and split to postEntity
   def postEnities(userSTS: String,
                   host: String,
                   bucket: String,
@@ -103,7 +101,8 @@ trait LineageHelpers extends LazyLogging with RestClient {
                   method: String,
                   contentType: ContentType,
                   clientType: String,
-                  timestamp: Long): Future[LineagePostGuidResponse] = {
+                  timestamp: Long,
+                 ): Future[LineagePostGuidResponse] = {
 
     def processIn(inputGUID: String, inputType: String) = List(guidRef(inputGUID, inputType))
 
@@ -115,12 +114,16 @@ trait LineageHelpers extends LazyLogging with RestClient {
       fileGuid <- postData(fileEntities(bucketGuid, bucketObject, userSTS, contentType, "customer_PII").toJson).map(r => r.entityGUID)
       processGuid <- method match {
         case access if access == "read" =>
-          postData( //todo: is this true assumtion that bucket is input?
-            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(bucketGuid, "Bucket"), processOut(fileGuid, "DataFile"), timestamp).toJson)
+          postData(
+            processEntities(
+              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(bucketGuid, "Bucket"), processOut(fileGuid, "DataFile"), clientType, timestamp)
+              .toJson)
             .map(r => r.entityGUID)
         case access if access == "write" =>
           postData(
-            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(fileGuid, "DataFile"), processOut(bucketGuid, "Bucket"), timestamp).toJson)
+            processEntities(
+              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(fileGuid, "DataFile"), processOut(bucketGuid, "Bucket"), clientType, timestamp)
+              .toJson)
             .map(r => r.entityGUID)
       }
     } yield LineagePostGuidResponse(serverGuid, bucketGuid, fileGuid, processGuid)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -1,7 +1,7 @@
 package com.ing.wbaa.airlock.proxy.provider.atlas
 
-import akka.http.scaladsl.model.{ContentType, HttpRequest}
-import com.ing.wbaa.airlock.proxy.data.{LineageGuidResponse, LineageHeaders, LineagePostGuidResponse}
+import akka.http.scaladsl.model.{ ContentType, HttpRequest }
+import com.ing.wbaa.airlock.proxy.data.{ LineageGuidResponse, LineageHeaders, LineagePostGuidResponse }
 import com.ing.wbaa.airlock.proxy.provider.atlas.Model._
 import com.typesafe.scalalogging.LazyLogging
 
@@ -24,11 +24,11 @@ trait LineageHelpers extends LazyLogging with RestClient {
       Seq(Classification(classification)))))
 
   private def fileEntities(
-                    bucketGuid: String,
-                    bucketObject: String,
-                    userSTS: String,
-                    contentType: ContentType,
-                    classification: String) = {
+      bucketGuid: String,
+      bucketObject: String,
+      userSTS: String,
+      contentType: ContentType,
+      classification: String) = {
     Entities(Seq(IngestedFile(
       "DataFile",
       userSTS,
@@ -38,15 +38,15 @@ trait LineageHelpers extends LazyLogging with RestClient {
   }
 
   private def processEntities(
-                       serverGuid: String,
-                       bucketGuid: String,
-                       fileGuid: String,
-                       userSTS: String,
-                       method: String,
-                       inputs: List[guidRef],
-                       outputs: List[guidRef],
-                       clientType: String,
-                       timestamp: Long) = {
+      serverGuid: String,
+      bucketGuid: String,
+      fileGuid: String,
+      userSTS: String,
+      method: String,
+      inputs: List[guidRef],
+      outputs: List[guidRef],
+      clientType: String,
+      timestamp: Long) = {
     Entities(Seq(Ingestion(
       "airlock_client",
       userSTS,
@@ -88,20 +88,20 @@ trait LineageHelpers extends LazyLogging with RestClient {
   // We need to come up with process of tracking file delete
   def deleteEntities(typeName: String, entityName: String): Future[LineageGuidResponse] =
     for {
-      entityGuid <- getEntityGUID(typeName, entityName)
-      _ <- deleteEntity(entityGuid)
+      entityGuidResponse <- getEntityGUID(typeName, entityName)
+      _ <- deleteEntity(entityGuidResponse.entityGUID)
 
-    } yield LineageGuidResponse(entityGuid)
+    } yield entityGuidResponse
 
-  def postEnities(userSTS: String,
-                  host: String,
-                  bucket: String,
-                  bucketObject: String,
-                  method: String,
-                  contentType: ContentType,
-                  clientType: String,
-                  timestamp: Long,
-                 ): Future[LineagePostGuidResponse] = {
+  def postEnities(
+      userSTS: String,
+      host: String,
+      bucket: String,
+      bucketObject: String,
+      method: String,
+      contentType: ContentType,
+      clientType: String,
+      timestamp: Long): Future[LineagePostGuidResponse] = {
 
     def processIn(inputGUID: String, inputType: String) = List(guidRef(inputGUID, inputType))
     def processOut(outputGUID: String, outputType: String) = List(guidRef(outputGUID, outputType))

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -114,14 +114,14 @@ trait LineageHelpers extends LazyLogging with RestClient {
         case access if access == "read" =>
           postData(
             processEntities(
-              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(bucketGuid, "Bucket"), processOut(fileGuid, "DataFile"), clientType, timestamp)
-              .toJson)
+              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(bucketGuid, "Bucket"), processOut(fileGuid, "DataFile"), clientType, timestamp
+            ).toJson)
             .map(r => r.entityGUID)
         case access if access == "write" =>
           postData(
             processEntities(
-              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(fileGuid, "DataFile"), processOut(bucketGuid, "Bucket"), clientType, timestamp)
-              .toJson)
+              serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(fileGuid, "DataFile"), processOut(bucketGuid, "Bucket"), clientType, timestamp
+            ).toJson)
             .map(r => r.entityGUID)
       }
     } yield LineagePostGuidResponse(serverGuid, bucketGuid, fileGuid, processGuid)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -1,15 +1,129 @@
 package com.ing.wbaa.airlock.proxy.provider.atlas
 
+import akka.http.scaladsl.model.{ContentType, HttpRequest}
+import com.ing.wbaa.airlock.proxy.data.{LineageHeaders, LineagePostGuidResponse}
+import com.ing.wbaa.airlock.proxy.provider.atlas.Model._
 import com.typesafe.scalalogging.LazyLogging
-import Model._
-import com.ing.wbaa.airlock.proxy.data.LineageGuidResponse
 
 import scala.concurrent.Future
 
-trait LineageHelpers extends LazyLogging {
+trait LineageHelpers extends LazyLogging with RestClient {
 
-  def postEntity(atlasEntity: AtlasEntity): Future[LineageGuidResponse] = {
+  def serverEntities(userSTS: String, host: String, classification: String) =
+    Entities(Seq(Server(
+      "Server",
+      userSTS,
+      ServerAttributes(host, host, host, host),
+      Seq(Classification(classification)))))
 
+  def bucketEntities(userSTS: String, bucket: String, classification: String) =
+    Entities(Seq(Bucket(
+      "Bucket",
+      userSTS,
+      BucketAttributes(bucket, bucket, bucket),
+      Seq(Classification(classification)))))
+
+  def fileEntities(
+                    bucketGuid: String,
+                    bucketObject: String,
+                    userSTS: String,
+                    contentType: ContentType,
+                    classification: String) = {
+    Entities(Seq(IngestedFile(
+      "DataFile",
+      userSTS,
+      FileAttributes(bucketObject, bucketObject, bucketObject, contentType.mediaType.value,
+        guidRef(bucketGuid, "Bucket"),
+        Seq(Classification(classification))))))
+  }
+
+  def processEntities(
+                       serverGuid: String,
+                       bucketGuid: String,
+                       fileGuid: String,
+                       userSTS: String,
+                       method: String,
+                       inputs: List[guidRef],
+                       outputs: List[guidRef],
+                       timestamp: Long) = {
+    Entities(Seq(Ingestion(
+      "airlock_client",
+      userSTS,
+      IngestionAttributes(s"aws_cli_${timestamp}", s"aws_cli_${timestamp}", method, userSTS,
+        guidRef(serverGuid, "Server"),
+        inputs,
+        outputs))))
+  }
+
+  private def extractClient(userAgent: String) =
+    """(\S+)/\S+""".r
+      .findFirstMatchIn(userAgent)
+      .map(_ group 1).getOrElse("")
+
+  // createLineageFromRequest is used in RequestHandlerS3 where there is no notion of S3Request. It seems easier to
+  // repeat httpRequest parsing here for needed values
+  def getLineageHeaders(httpRequest: HttpRequest): LineageHeaders = {
+    val host = httpRequest.getHeader("Remote-Address").get().value() // make option
+    val path = httpRequest.uri.path.toString().split("/")
+    val bucket = path.take(path.length - 1).mkString("/")
+    val bucketObject = path.lastOption.getOrElse("emptyObject")
+    val method = httpRequest.method
+    val contentType = httpRequest.entity.contentType
+    val clientType = extractClient(httpRequest.getHeader("User-Agent").get().value()) // make option
+
+    LineageHeaders(host, bucket, bucketObject, method, contentType, clientType)
+  }
+
+  def splitQueryToJavaMap(queryString: String): Map[String, List[String]] =
+    queryString.split("&").map { paramAndValue =>
+      paramAndValue.split("=")
+        .grouped(2)
+        .map {
+          case Array(k, v) => (k, List(v))
+          case Array(k)    => (k, List(""))
+        }
+    }.toList.flatten.toMap
+
+  // file entity delete
+  // for now it is just deleting file entity and no related objects like eg. aws_cli_script, which uploaded or downloaded
+  // file to bucket. Once we delete aws_cli_script object we will lose track of whats has been deleted
+  // We need to come up with process of tracking file delete
+  def deleteEntities(typeName: String, entityName: String): Future[LineagePostGuidResponse] =
+    for {
+      entityGuid <- getEntityGUID(typeName, entityName)
+      _ <- deleteEntity(entityGuid)
+
+    } yield LineagePostGuidResponse("", "", entityGuid, "")
+
+  // move to LineageHelpers and split to postEntity
+  def postEnities(userSTS: String,
+                  host: String,
+                  bucket: String,
+                  bucketObject: String,
+                  method: String,
+                  contentType: ContentType,
+                  clientType: String,
+                  timestamp: Long): Future[LineagePostGuidResponse] = {
+
+    def processIn(inputGUID: String, inputType: String) = List(guidRef(inputGUID, inputType))
+
+    def processOut(outputGUID: String, outputType: String) = List(guidRef(outputGUID, outputType))
+
+    for {
+      serverGuid <- postData(serverEntities(userSTS, host, "staging_node").toJson).map(r => r.entityGUID)
+      bucketGuid <- postData(bucketEntities(userSTS, bucket, "customer_PII").toJson).map(r => r.entityGUID)
+      fileGuid <- postData(fileEntities(bucketGuid, bucketObject, userSTS, contentType, "customer_PII").toJson).map(r => r.entityGUID)
+      processGuid <- method match {
+        case access if access == "read" =>
+          postData( //todo: is this true assumtion that bucket is input?
+            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(bucketGuid, "Bucket"), processOut(fileGuid, "DataFile"), timestamp).toJson)
+            .map(r => r.entityGUID)
+        case access if access == "write" =>
+          postData(
+            processEntities(serverGuid, bucketGuid, fileGuid, userSTS, method, processIn(fileGuid, "DataFile"), processOut(bucketGuid, "Bucket"), timestamp).toJson)
+            .map(r => r.entityGUID)
+      }
+    } yield LineagePostGuidResponse(serverGuid, bucketGuid, fileGuid, processGuid)
   }
 
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -1,0 +1,15 @@
+package com.ing.wbaa.airlock.proxy.provider.atlas
+
+import com.typesafe.scalalogging.LazyLogging
+import Model._
+import com.ing.wbaa.airlock.proxy.data.LineageGuidResponse
+
+import scala.concurrent.Future
+
+trait LineageHelpers extends LazyLogging {
+
+  def postEntity(atlasEntity: AtlasEntity): Future[LineageGuidResponse] = {
+
+  }
+
+}

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
@@ -21,16 +21,6 @@ object Model extends ModelJsonSupport {
   // dependency shortcut
   case class guidRef(guid: String, typeName: String)
 
-  // input objects
-  trait Inputs {
-    def inputs: List[guidRef]
-  }
-
-  // output objects
-  trait Outputs {
-    def outputs: List[guidRef]
-  }
-
   // Infra entity - server
   case class ServerAttributes(
       qualifiedName: String,
@@ -66,7 +56,7 @@ object Model extends ModelJsonSupport {
       run_as: String,
       Server: guidRef,
       inputs: List[guidRef],
-      outputs: List[guidRef]) extends Asset with Referenceable with Inputs with Outputs
+      outputs: List[guidRef]) extends Asset with Referenceable
 
   case class Ingestion(
       typeName: String,

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
@@ -33,84 +33,82 @@ object Model extends ModelJsonSupport {
 
   // Infra entity - server
   case class ServerAttributes(
-                               qualifiedName: String,
-                               name: String,
-                               server_name: String,
-                               ip_address: String)
+      qualifiedName: String,
+      name: String,
+      server_name: String,
+      ip_address: String)
     extends Asset with Referenceable
 
   case class Server(
-                     typeName: String,
-                     createdBy: String,
-                     attributes: ServerAttributes,
-                     classifications: Seq[Classification]) extends AtlasEntity
+      typeName: String,
+      createdBy: String,
+      attributes: ServerAttributes,
+      classifications: Seq[Classification]) extends AtlasEntity
 
   // Infra entity - bucket
   case class BucketAttributes(
-                               qualifiedName: String,
-                               name: String,
-                               bucket_name: String)
+      qualifiedName: String,
+      name: String,
+      bucket_name: String)
     extends Asset with Referenceable
 
   case class Bucket(
-                     typeName: String,
-                     createdBy: String,
-                     attributes: BucketAttributes,
-                     classifications: Seq[Classification]) extends AtlasEntity
+      typeName: String,
+      createdBy: String,
+      attributes: BucketAttributes,
+      classifications: Seq[Classification]) extends AtlasEntity
 
   // Ingestion Process
   case class IngestionAttributes(
-                                  qualifiedName: String,
-                                  name: String,
-                                  operation: String,
-                                  run_as: String,
-                                  Server: guidRef,
-                                  inputs: List[guidRef],
-                                  outputs: List[guidRef]) extends Asset with Referenceable with Inputs with Outputs
+      qualifiedName: String,
+      name: String,
+      operation: String,
+      run_as: String,
+      Server: guidRef,
+      inputs: List[guidRef],
+      outputs: List[guidRef]) extends Asset with Referenceable with Inputs with Outputs
 
   case class Ingestion(
-                        typeName: String,
-                        createdBy: String,
-                        attributes: IngestionAttributes) extends AtlasEntity
+      typeName: String,
+      createdBy: String,
+      attributes: IngestionAttributes) extends AtlasEntity
 
   // Ingestion File
   case class FileAttributes(
-                             qualifiedName: String,
-                             name: String,
-                             file_name: String,
-                             format: String,
-                             bucket: guidRef,
-                             inputs: List[guidRef],
-                             outputs: List[guidRef],
-                             classifications: Seq[Classification]) extends Asset with Referenceable with Inputs with Outputs
+      qualifiedName: String,
+      name: String,
+      file_name: String,
+      format: String,
+      bucket: guidRef,
+      classifications: Seq[Classification]) extends Asset with Referenceable
 
   case class IngestedFile(
-                           typeName: String,
-                           createdBy: String,
-                           attributes: FileAttributes) extends AtlasEntity
+      typeName: String,
+      createdBy: String,
+      attributes: FileAttributes) extends AtlasEntity
 
   // Entities Sequence
   case class Entities[A <: AtlasEntity](entities: Seq[A])
 
   // Entity search result
   case class EntityId(
-                       state: String,
-                       jsonClass: String,
-                       typeName: String,
-                       version: Int,
-                       id: String)
+      state: String,
+      jsonClass: String,
+      typeName: String,
+      version: Int,
+      id: String)
 
   case class Definition(
-                         typeName: String,
-                         values: JsObject,
-                         id: EntityId,
-                         traits: JsObject,
-                         traitNames: JsObject,
-                         systemAttributes: JsObject, jsonClass: String)
+      typeName: String,
+      values: JsObject,
+      id: EntityId,
+      traits: JsObject,
+      traitNames: JsObject,
+      systemAttributes: JsObject, jsonClass: String)
 
   case class EntitySearchResult(
-                                 requestId: String,
-                                 definition: JsObject)
+      requestId: String,
+      definition: JsObject)
 
   // Entity create / update result
   trait GuidResponse {
@@ -118,10 +116,9 @@ object Model extends ModelJsonSupport {
   }
 
   case class CreateResponse(
-                             mutatedEntities: JsObject,
-                             guidAssignments: JsObject) extends GuidResponse
+      mutatedEntities: JsObject,
+      guidAssignments: JsObject) extends GuidResponse
 
   case class UpdateResponse(guidAssignments: JsObject) extends GuidResponse
-
 
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
@@ -1,9 +1,10 @@
 package com.ing.wbaa.airlock.proxy.provider.atlas
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import spray.json._
 
-object Model extends AtlasModelJsonSupport {
+object Model extends ModelJsonSupport {
+
+  trait AtlasEntity
 
   // root atlas types
   trait Asset {
@@ -155,37 +156,5 @@ object Model extends AtlasModelJsonSupport {
       blockedPropagatedClassifications: JsObject)
 
   case class RelationshipResponse(relationship: Relationship)
-
-}
-
-trait AtlasModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
-  import Model._
-
-  //generic
-  implicit val readsClassification = jsonFormat1(Classification)
-  implicit val readsGuidRef = jsonFormat2(guidRef)
-  //server
-  implicit val readsServerAttributes = jsonFormat4(ServerAttributes)
-  implicit val readsServer = jsonFormat4(Server)
-  implicit val readsServerEntities = jsonFormat1(Entities[Server])
-  //bucket
-  implicit val readsBucketAttributes = jsonFormat3(BucketAttributes)
-  implicit val readsBucket = jsonFormat4(Bucket)
-  implicit val readsBucketEntities = jsonFormat1(Entities[Bucket])
-  // Entity search result
-  implicit val idReader = jsonFormat5(EntityId)
-  implicit val readsDefinition = jsonFormat7(Definition)
-  implicit val resultReader = jsonFormat2(EntitySearchResult)
-  // Entity create / update result
-  implicit val readsCreateResponse = jsonFormat2(CreateResponse)
-  implicit val readsUpdateResponse = jsonFormat1(UpdateResponse)
-  // IngestionProcess
-  implicit val readsIngestionAttributes = jsonFormat7(IngestionAttributes)
-  implicit val readsIngestion = jsonFormat3(Ingestion)
-  implicit val readsIngestionEntities = jsonFormat1(Entities[Ingestion])
-  // File
-  implicit val readsFileAttributes = jsonFormat9(FileAttributes)
-  implicit val readsFile = jsonFormat3(IngestedFile)
-  implicit val readsFileEntities = jsonFormat1(Entities[IngestedFile])
 
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/Model.scala
@@ -18,10 +18,6 @@ object Model extends ModelJsonSupport {
   // classification of objects in atlas
   case class Classification(typeName: String)
 
-  // Infra entity - server
-  case class ServerAttributes(qualifiedName: String, name: String, server_name: String, ip_address: String)
-    extends Asset with Referenceable
-
   // dependency shortcut
   case class guidRef(guid: String, typeName: String)
 
@@ -35,83 +31,86 @@ object Model extends ModelJsonSupport {
     def outputs: List[guidRef]
   }
 
+  // Infra entity - server
+  case class ServerAttributes(
+                               qualifiedName: String,
+                               name: String,
+                               server_name: String,
+                               ip_address: String)
+    extends Asset with Referenceable
+
   case class Server(
-      typeName: String,
-      createdBy: String,
-      attributes: ServerAttributes,
-      classifications: Seq[Classification])
+                     typeName: String,
+                     createdBy: String,
+                     attributes: ServerAttributes,
+                     classifications: Seq[Classification]) extends AtlasEntity
 
   // Infra entity - bucket
   case class BucketAttributes(
-      qualifiedName: String,
-      name: String,
-      bucket_name: String)
+                               qualifiedName: String,
+                               name: String,
+                               bucket_name: String)
     extends Asset with Referenceable
 
   case class Bucket(
-      typeName: String,
-      createdBy: String,
-      attributes: BucketAttributes,
-      classifications: Seq[Classification])
+                     typeName: String,
+                     createdBy: String,
+                     attributes: BucketAttributes,
+                     classifications: Seq[Classification]) extends AtlasEntity
 
   // Ingestion Process
   case class IngestionAttributes(
-      qualifiedName: String,
-      name: String,
-      operation: String,
-      run_as: String,
-      Server: guidRef,
-      inputs: List[guidRef],
-      outputs: List[guidRef])
-    extends Asset with Referenceable with Inputs with Outputs
+                                  qualifiedName: String,
+                                  name: String,
+                                  operation: String,
+                                  run_as: String,
+                                  Server: guidRef,
+                                  inputs: List[guidRef],
+                                  outputs: List[guidRef]) extends Asset with Referenceable with Inputs with Outputs
 
   case class Ingestion(
-      typeName: String,
-      createdBy: String,
-      attributes: IngestionAttributes
-  )
+                        typeName: String,
+                        createdBy: String,
+                        attributes: IngestionAttributes) extends AtlasEntity
 
   // Ingestion File
   case class FileAttributes(
-      qualifiedName: String,
-      name: String,
-      file_name: String,
-      format: String,
-      bucket: guidRef,
-      Server: guidRef,
-      inputs: List[guidRef],
-      outputs: List[guidRef],
-      classifications: Seq[Classification])
-    extends Asset with Referenceable with Inputs with Outputs
+                             qualifiedName: String,
+                             name: String,
+                             file_name: String,
+                             format: String,
+                             bucket: guidRef,
+                             inputs: List[guidRef],
+                             outputs: List[guidRef],
+                             classifications: Seq[Classification]) extends Asset with Referenceable with Inputs with Outputs
 
   case class IngestedFile(
-      typeName: String,
-      createdBy: String,
-      attributes: FileAttributes
-  )
+                           typeName: String,
+                           createdBy: String,
+                           attributes: FileAttributes) extends AtlasEntity
 
   // Entities Sequence
-  case class Entities[A](entities: Seq[A])
+  case class Entities[A <: AtlasEntity](entities: Seq[A])
 
   // Entity search result
   case class EntityId(
-      state: String,
-      jsonClass: String,
-      typeName: String,
-      version: Int,
-      id: String)
+                       state: String,
+                       jsonClass: String,
+                       typeName: String,
+                       version: Int,
+                       id: String)
 
   case class Definition(
-      typeName: String,
-      values: JsObject,
-      id: EntityId,
-      traits: JsObject,
-      traitNames: JsObject,
-      systemAttributes: JsObject, jsonClass: String)
+                         typeName: String,
+                         values: JsObject,
+                         id: EntityId,
+                         traits: JsObject,
+                         traitNames: JsObject,
+                         systemAttributes: JsObject, jsonClass: String)
 
   case class EntitySearchResult(
-      requestId: String,
-      definition: JsObject)
+                                 requestId: String,
+                                 definition: JsObject)
 
   // Entity create / update result
   trait GuidResponse {
@@ -119,42 +118,10 @@ object Model extends ModelJsonSupport {
   }
 
   case class CreateResponse(
-      mutatedEntities: JsObject,
-      guidAssignments: JsObject) extends GuidResponse
+                             mutatedEntities: JsObject,
+                             guidAssignments: JsObject) extends GuidResponse
 
   case class UpdateResponse(guidAssignments: JsObject) extends GuidResponse
 
-  // lineage response
-  // below four classes (LineageRelations, LineageResponse, Relationship, RelationshipResponse) are not used at the moment.
-  // they are to be used, once we start working with entities lineage
-  case class LineageRelations(
-      fromEntityId: String,
-      toEntityId: String,
-      relationshipId: String)
-
-  case class LineageResponse(
-      baseEntityGuid: String,
-      lineageDirection: String,
-      lineageDepth: Int,
-      guidEntityMap: JsObject,
-      relations: Seq[LineageRelations])
-
-  case class Relationship(
-      typeName: String,
-      guid: String,
-      end1: JsObject,
-      end2: JsObject,
-      label: String,
-      propagateTags: String,
-      status: String,
-      createdBy: String,
-      updatedBy: String,
-      createTime: Long,
-      updateTime: Long,
-      version: Int,
-      propagatedClassifications: JsObject,
-      blockedPropagatedClassifications: JsObject)
-
-  case class RelationshipResponse(relationship: Relationship)
 
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
@@ -29,7 +29,7 @@ trait ModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val readsIngestion = jsonFormat3(Ingestion)
   implicit val readsIngestionEntities = jsonFormat1(Entities[Ingestion])
   // File
-  implicit val readsFileAttributes = jsonFormat8(FileAttributes)
+  implicit val readsFileAttributes = jsonFormat6(FileAttributes)
   implicit val readsFile = jsonFormat3(IngestedFile)
   implicit val readsFileEntities = jsonFormat1(Entities[IngestedFile])
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
@@ -1,6 +1,7 @@
 package com.ing.wbaa.airlock.proxy.provider.atlas
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import com.ing.wbaa.airlock.proxy.data.LineageGuidResponse
 import spray.json.DefaultJsonProtocol
 
 trait ModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
@@ -21,6 +22,7 @@ trait ModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val idReader = jsonFormat5(EntityId)
   implicit val readsDefinition = jsonFormat7(Definition)
   implicit val resultReader = jsonFormat2(EntitySearchResult)
+  implicit val guidResponse = jsonFormat1(LineageGuidResponse)
   // Entity create / update result
   implicit val readsCreateResponse = jsonFormat2(CreateResponse)
   implicit val readsUpdateResponse = jsonFormat1(UpdateResponse)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
@@ -1,0 +1,36 @@
+package com.ing.wbaa.airlock.proxy.provider.atlas
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json.DefaultJsonProtocol
+
+trait ModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+  import Model._
+
+  //generic
+  implicit val readsClassification = jsonFormat1(Classification)
+  implicit val readsGuidRef = jsonFormat2(guidRef)
+  //server
+  implicit val readsServerAttributes = jsonFormat4(ServerAttributes)
+  implicit val readsServer = jsonFormat4(Server)
+  implicit val readsServerEntities = jsonFormat1(Entities[Server])
+  //bucket
+  implicit val readsBucketAttributes = jsonFormat3(BucketAttributes)
+  implicit val readsBucket = jsonFormat4(Bucket)
+  implicit val readsBucketEntities = jsonFormat1(Entities[Bucket])
+  // Entity search result
+  implicit val idReader = jsonFormat5(EntityId)
+  implicit val readsDefinition = jsonFormat7(Definition)
+  implicit val resultReader = jsonFormat2(EntitySearchResult)
+  // Entity create / update result
+  implicit val readsCreateResponse = jsonFormat2(CreateResponse)
+  implicit val readsUpdateResponse = jsonFormat1(UpdateResponse)
+  // IngestionProcess
+  implicit val readsIngestionAttributes = jsonFormat7(IngestionAttributes)
+  implicit val readsIngestion = jsonFormat3(Ingestion)
+  implicit val readsIngestionEntities = jsonFormat1(Entities[Ingestion])
+  // File
+  implicit val readsFileAttributes = jsonFormat9(FileAttributes)
+  implicit val readsFile = jsonFormat3(IngestedFile)
+  implicit val readsFileEntities = jsonFormat1(Entities[IngestedFile])
+
+}

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/ModelJsonSupport.scala
@@ -29,7 +29,7 @@ trait ModelJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val readsIngestion = jsonFormat3(Ingestion)
   implicit val readsIngestionEntities = jsonFormat1(Entities[Ingestion])
   // File
-  implicit val readsFileAttributes = jsonFormat9(FileAttributes)
+  implicit val readsFileAttributes = jsonFormat8(FileAttributes)
   implicit val readsFile = jsonFormat3(IngestedFile)
   implicit val readsFileEntities = jsonFormat1(Entities[IngestedFile])
 

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlasSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlasSpec.scala
@@ -1,10 +1,10 @@
 package com.ing.wbaa.airlock.proxy.provider
 
-import com.ing.wbaa.airlock.proxy.provider.atlas.AtlasModelJsonSupport
+import com.ing.wbaa.airlock.proxy.provider.atlas.ModelJsonSupport
 import com.ing.wbaa.airlock.proxy.provider.atlas.Model.{ Bucket, BucketAttributes, Classification, CreateResponse, Entities, FileAttributes, IngestedFile, Ingestion, IngestionAttributes, Server, ServerAttributes, UpdateResponse, guidRef }
 import org.scalatest.{ DiagrammedAssertions, WordSpec }
 
-class LineageProviderAtlasSpec extends WordSpec with DiagrammedAssertions with AtlasModelJsonSupport {
+class LineageProviderAtlasSpec extends WordSpec with DiagrammedAssertions with ModelJsonSupport {
   import spray.json._
 
   val timestamp = System.currentTimeMillis()
@@ -43,14 +43,11 @@ class LineageProviderAtlasSpec extends WordSpec with DiagrammedAssertions with A
           "fakeUser",
           FileAttributes("fakeObject", "fakeObject", "fakeObject", "application/octet-stream",
             guidRef("f0a46ae7-481a-4bbf-a202-44bdff598ab5", "Bucket"),
-            guidRef("4af9ec97-b320-4e3b-9363-5763fa63b03b", "Server"),
-            List(guidRef("4af9ec97-b320-4e3b-9363-5763fa63b03b", "Server")),
-            List(guidRef("f0a46ae7-481a-4bbf-a202-44bdff598ab5", "Bucket")),
             Seq(Classification("customer_PII"))))))
           .toJson
           .toString()
       val jsonEntities =
-        """{"entities":[{"typeName":"DataFile","createdBy":"fakeUser","attributes":{"format":"application/octet-stream","name":"fakeObject","Server":{"guid":"4af9ec97-b320-4e3b-9363-5763fa63b03b","typeName":"Server"},"file_name":"fakeObject","outputs":[{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}],"classifications":[{"typeName":"customer_PII"}],"inputs":[{"guid":"4af9ec97-b320-4e3b-9363-5763fa63b03b","typeName":"Server"}],"qualifiedName":"fakeObject","bucket":{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}}}]}"""
+        """{"entities":[{"typeName":"DataFile","createdBy":"fakeUser","attributes":{"format":"application/octet-stream","name":"fakeObject","file_name":"fakeObject","classifications":[{"typeName":"customer_PII"}],"qualifiedName":"fakeObject","bucket":{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}}}]}"""
 
       assert(testFileEntities == jsonEntities)
     }
@@ -64,14 +61,11 @@ class LineageProviderAtlasSpec extends WordSpec with DiagrammedAssertions with A
           "fakeUser",
           FileAttributes("fakeObject", "fakeObject", "fakeObject", "none/none",
             guidRef("f0a46ae7-481a-4bbf-a202-44bdff598ab5", "Bucket"),
-            guidRef("4af9ec97-b320-4e3b-9363-5763fa63b03b", "Server"),
-            List(guidRef("f0a46ae7-481a-4bbf-a202-44bdff598ab5", "Bucket")),
-            List(guidRef("4af9ec97-b320-4e3b-9363-5763fa63b03b", "Server")),
             Seq(Classification("customer_PII"))))))
           .toJson
           .toString()
       val jsonEntities =
-        s"""{"entities":[{"typeName":"DataFile","createdBy":"fakeUser","attributes":{"format":"none/none","name":"fakeObject","Server":{"guid":"4af9ec97-b320-4e3b-9363-5763fa63b03b","typeName":"Server"},"file_name":"fakeObject","outputs":[{"guid":"4af9ec97-b320-4e3b-9363-5763fa63b03b","typeName":"Server"}],"classifications":[{"typeName":"customer_PII"}],"inputs":[{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}],"qualifiedName":"fakeObject","bucket":{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}}}]}"""
+        s"""{"entities":[{"typeName":"DataFile","createdBy":"fakeUser","attributes":{"format":"none/none","name":"fakeObject","file_name":"fakeObject","classifications":[{"typeName":"customer_PII"}],"qualifiedName":"fakeObject","bucket":{"guid":"f0a46ae7-481a-4bbf-a202-44bdff598ab5","typeName":"Bucket"}}}]}"""
 
       assert(testFileEntities == jsonEntities)
     }


### PR DESCRIPTION
- airlock client is now taken from User-Agent header
- added lineage for mv, cp between buckets
- head requests are no longer reported
-  IP changed to remote IP
- one row reported for multi request aws ops