### PR TITLE
Folder level permission check in Ranger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,7 @@ before_script:
 - sbt ++$TRAVIS_SCALA_VERSION clean compile
 - echo "Wait for containers to be up and running"
 - bash waitForContainerSetup.sh
-- docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
-- docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
-- docker-compose exec ceph s3cmd mb s3://home
-- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
-- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/
+- bash setupS3Env.sh
 
 script:
 - echo "Running pipeline for branch ${TRAVIS_BRANCH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
 - echo "Wait for containers to be up and running"
 - bash waitForContainerSetup.sh
 - docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
+- docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
 
 script:
 - echo "Running pipeline for branch ${TRAVIS_BRANCH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ before_script:
 - bash waitForContainerSetup.sh
 - docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
 - docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
+- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
+- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/
 
 script:
 - echo "Running pipeline for branch ${TRAVIS_BRANCH}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
 - bash waitForContainerSetup.sh
 - docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
 - docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
+- docker-compose exec ceph s3cmd mb s3://home
 - docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
 - docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: nielsdenissen/airlock-dev-apache-ranger-postgres:0.0.8
 
   ranger-admin:
-    image: nielsdenissen/airlock-dev-apache-ranger:0.0.9
+    image: nielsdenissen/airlock-dev-apache-ranger:0.0.10
     stdin_open: true
     tty: true
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: nielsdenissen/airlock-dev-apache-ranger-postgres:0.0.8
 
   ranger-admin:
-    image: nielsdenissen/airlock-dev-apache-ranger:0.0.10
+    image: nielsdenissen/airlock-dev-apache-ranger:0.0.11
     stdin_open: true
     tty: true
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: wbaa/airlock-dev-apache-ranger-postgres:0.0.8
 
   ranger-admin:
-    image: wbaa/airlock-dev-apache-ranger:0.0.11
+    image: wbaa/airlock-dev-apache-ranger:0.0.12
     stdin_open: true
     tty: true
     depends_on:

--- a/setupS3Env.sh
+++ b/setupS3Env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+- docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
+- docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
+- docker-compose exec ceph s3cmd mb s3://home
+- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
+- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/

--- a/setupS3Env.sh
+++ b/setupS3Env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-- docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
-- docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
-- docker-compose exec ceph s3cmd mb s3://home
-- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
-- docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/
+docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
+docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
+docker-compose exec ceph s3cmd mb s3://home
+docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/
+docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser1/

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RadosGatewayHandlerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RadosGatewayHandlerItTest.scala
@@ -97,7 +97,7 @@ class RadosGatewayHandlerItTest extends WordSpec with DiagrammedAssertions with 
     }
 
     "list all buckets" in {
-      assert(listAllBuckets.head == "demobucket")
+      assert(listAllBuckets.head == "home")
     }
   }
 }

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -15,7 +15,7 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
 
   val s3Request = S3Request(
     AwsRequestCredential(AwsAccessKey("accesskey"), Some(AwsSessionToken("sessiontoken"))),
-    Some("demobucket"),
+    Some("/demobucket"),
     None,
     Read
   )
@@ -61,11 +61,11 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "authorize for requests without bucket" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucket = None), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None), user, clientIPAddress, headerIPs))
       }
 
       "doesn't authorize for requests that are not supposed to be (Write)" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write), user, clientIPAddress, headerIPs))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write, bucketObjectRoot = Some("object")), user, clientIPAddress, headerIPs))
       }
 
       "doesn't authorize for unauthorized user and group" in withAuthorizationProviderRanger() { apr =>
@@ -82,13 +82,13 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "authorize allow-list-buckets with default settings" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucket = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
       }
 
       "does authorize allow-list-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val listBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucket = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
       }
 
       "does authorize allow-create-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -128,6 +128,10 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
         assert(!apr.isUserAuthorizedForRequest(s3Request, user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
       }
 
+      "doesn't allow listing subdir in the bucket" in withAuthorizationProviderRanger() { apr =>
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/demobucket/subdir")), user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
+      }
+
     }
   }
 }

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -132,6 +132,26 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
         assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/demobucket/subdir")), user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
       }
 
+      "does allow read homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/home/testuser")), user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
+      }
+
+      "doesn't allow read in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/home/testuser1")), user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
+      }
+
+      "does allow write homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
+        assert(apr.isUserAuthorizedForRequest(
+          s3Request.copy(s3BucketPath = Some("/home/testuser"), bucketObjectRoot = Some("object1"), accessType = Write),
+          user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
+      }
+
+      "doesn't allow write in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
+        assert(!apr.isUserAuthorizedForRequest(
+          s3Request.copy(s3BucketPath = Some("/home/testuser1"), bucketObjectRoot = Some("object1"), accessType = Write),
+          user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
+      }
+
     }
   }
 }

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -57,7 +57,7 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "successfully authorizes a request on an object in a bucket" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucketObjectRoot = Some("object")), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = Some("object")), user, clientIPAddress, headerIPs))
       }
 
       "authorize for requests without bucket" in withAuthorizationProviderRanger() { apr =>
@@ -65,7 +65,7 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "doesn't authorize for requests that are not supposed to be (Write)" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write, bucketObjectRoot = Some("object")), user, clientIPAddress, headerIPs))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write, s3Object = Some("object")), user, clientIPAddress, headerIPs))
       }
 
       "doesn't authorize for unauthorized user and group" in withAuthorizationProviderRanger() { apr =>
@@ -82,29 +82,29 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "authorize allow-list-buckets with default settings" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None, accessType = Read), user, clientIPAddress, headerIPs))
       }
 
       "does authorize allow-list-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val listBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, bucketObjectRoot = None, accessType = Read), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None, accessType = Read), user, clientIPAddress, headerIPs))
       }
 
       "does authorize allow-create-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucketObjectRoot = None, accessType = Write), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Write), user, clientIPAddress, headerIPs))
       }
 
       "does authorize delete buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(bucketObjectRoot = None, accessType = Delete), user, clientIPAddress, headerIPs))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Delete), user, clientIPAddress, headerIPs))
       }
 
       "doesn't authorize when method is not REST (GET, PUT, DELETE etc.)" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(bucketObjectRoot = None, accessType = NoAccess), user, clientIPAddress, headerIPs))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = NoAccess), user, clientIPAddress, headerIPs))
       }
 
       "doesn't authorize when remoteIpAddress is in a DENY policy" in withAuthorizationProviderRanger() { apr =>
@@ -142,13 +142,13 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
 
       "does allow write homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(
-          s3Request.copy(s3BucketPath = Some("/home/testuser"), bucketObjectRoot = Some("object1"), accessType = Write),
+          s3Request.copy(s3BucketPath = Some("/home/testuser"), s3Object = Some("object1"), accessType = Write),
           user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
       }
 
       "doesn't allow write in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(
-          s3Request.copy(s3BucketPath = Some("/home/testuser1"), bucketObjectRoot = Some("object1"), accessType = Write),
+          s3Request.copy(s3BucketPath = Some("/home/testuser1"), s3Object = Some("object1"), accessType = Write),
           user, clientIPAddress, headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))))
       }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
@@ -3,7 +3,7 @@ package com.ing.wbaa.airlock.proxy.api.directive
 import java.net.InetAddress
 
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.http.scaladsl.model.{ HttpHeader, HttpRequest, RemoteAddress }
+import akka.http.scaladsl.model.{ HttpHeader, HttpRequest, RemoteAddress, Uri }
 import akka.http.scaladsl.server.Directive1
 import com.ing.wbaa.airlock.proxy.data._
 import com.typesafe.scalalogging.LazyLogging
@@ -62,9 +62,25 @@ object ProxyDirectives extends LazyLogging {
         case Tuple1(optionalSessionToken) =>
           headerValue[AwsAccessKey](extractAuthorizationS3) tmap { case Tuple1(awsAccessKey) =>
 
+            // aws is passing subdir in prefix parameter if no object is used, eg. list bucket objects
+            val s3path = httpRequest.uri.rawQueryString match {
+              case Some(queryString) if queryString.contains("prefix") =>
+                val queryPrefixPair = queryString
+                  .split("&")
+                  .filter(_.contains("prefix"))
+                  .head.split("=")
+
+                if (queryPrefixPair.length == 2) {
+                  Uri.Path(s"${httpRequest.uri.path}/${queryPrefixPair.last.replace("%2F", "/")}")
+                } else {
+                  Uri.Path(s"${httpRequest.uri.path}")
+                }
+              case _     => httpRequest.uri.path
+            }
+
             val s3Request = S3Request(
               AwsRequestCredential(awsAccessKey, optionalSessionToken.map(AwsSessionToken)),
-              httpRequest.uri.path,
+              s3path,
               httpRequest.method
             )
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
@@ -70,8 +70,13 @@ object ProxyDirectives extends LazyLogging {
                   .filter(_.contains("prefix"))
                   .head.split("=")
 
+                val delimiter = queryString
+                  .split("&")
+                  .filter(_.contains("delimiter"))
+                  .head.split("=").last
+
                 if (queryPrefixPair.length == 2) {
-                  Uri.Path(s"${httpRequest.uri.path}/${queryPrefixPair.last.replace("%2F", "/")}")
+                  Uri.Path(s"${httpRequest.uri.path}/${queryPrefixPair.last.replace(delimiter, "/")}")
                 } else {
                   Uri.Path(s"${httpRequest.uri.path}")
                 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
@@ -7,14 +7,14 @@ import com.typesafe.scalalogging.LazyLogging
 /**
  * @param credential
  * @param s3BucketPath     A None for bucket means this is an operation not targeted to a specific bucket (e.g. list buckets)
- * @param bucketObjectRoot
+ * @param s3Object
  * @param accessType The access type for this request, write includes actions like write/update/delete
  *
  */
 case class S3Request(
     credential: AwsRequestCredential,
     s3BucketPath: Option[String],
-    bucketObjectRoot: Option[String],
+    s3Object: Option[String],
     accessType: AccessType
 )
 
@@ -23,7 +23,7 @@ object S3Request extends LazyLogging {
 
     val pathString = path.toString()
     val s3path = if (path.length > 1) { Some(pathString) } else { None }
-    val bucketObjectRoot =
+    val s3Object =
       if (pathString.endsWith("/") || pathString.split("/").length < 3) {
         None
       } else {
@@ -41,6 +41,6 @@ object S3Request extends LazyLogging {
         NoAccess
     }
 
-    S3Request(credential, s3path, bucketObjectRoot, accessType)
+    S3Request(credential, s3path, s3Object, accessType)
   }
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
@@ -19,16 +19,18 @@ case class S3Request(
 )
 
 object S3Request extends LazyLogging {
+  def extractObject(pathString: String): Option[String] =
+    if (pathString.endsWith("/") || pathString.split("/").length < 3) {
+      None
+    } else {
+      Some(pathString.split("/").last)
+    }
+
   def apply(credential: AwsRequestCredential, path: Path, httpMethod: HttpMethod): S3Request = {
 
     val pathString = path.toString()
     val s3path = if (path.length > 1) { Some(pathString) } else { None }
-    val s3Object =
-      if (pathString.endsWith("/") || pathString.split("/").length < 3) {
-        None
-      } else {
-        Some(pathString.split("/").last)
-      }
+    val s3Object = extractObject(pathString)
 
     val accessType = httpMethod.value match {
       case "GET"    => Read

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -86,7 +86,7 @@ trait AuthorizationProviderRanger extends LazyLogging {
       case S3Request(_, Some(s3path), None, accessType) if accessType == Read || accessType == Head =>
         isAuthorisedByRanger(s3path)
 
-      // create / delete bucket opetation
+      // create / delete bucket operation
       case S3Request(_, Some(_), None, accessType) if (accessType == Write || accessType == Delete) && rangerSettings.createBucketsEnabled =>
         logger.debug(s"Skipping ranger for creation/deletion of bucket with request: $request")
         true

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -44,11 +44,11 @@ trait AuthorizationProviderRanger extends LazyLogging {
    */
   def isUserAuthorizedForRequest(request: S3Request, user: User, clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): Boolean = {
 
-    def isAuthorisedByRanger(bucket: String): Boolean = {
+    def isAuthorisedByRanger(s3path: String): Boolean = {
       import scala.collection.JavaConverters._
 
       val rangerResource = new RangerAccessResourceImpl(
-        Map[String, AnyRef]("path" -> bucket).asJava
+        Map[String, AnyRef]("path" -> s3path).asJava
       )
 
       val rangerRequest = new RangerAccessRequestImpl(
@@ -71,15 +71,15 @@ trait AuthorizationProviderRanger extends LazyLogging {
           false
       }
     }
-
+    //todo: check object conditions - last is always object? aws is not adding subdir unless object is passed?
     request match {
       // object operations, put / delete etc.
-      case S3Request(_, Some(bucket), Some(_), _) =>
-        isAuthorisedByRanger(bucket)
+      case S3Request(_, Some(s3path), Some(_), _) =>
+        isAuthorisedByRanger(s3path)
 
       // list-objects in the bucket operation
-      case S3Request(_, Some(bucket), None, accessType) if accessType == Read || accessType == Head =>
-        isAuthorisedByRanger(bucket)
+      case S3Request(_, Some(s3path), None, accessType) if accessType == Read || accessType == Head =>
+        isAuthorisedByRanger(s3path)
 
       // create / delete bucket opetation
       case S3Request(_, Some(_), None, accessType) if (accessType == Write || accessType == Delete) && rangerSettings.createBucketsEnabled =>

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -77,6 +77,11 @@ trait AuthorizationProviderRanger extends LazyLogging {
       case S3Request(_, Some(s3path), Some(_), _) =>
         isAuthorisedByRanger(s3path)
 
+      // object operation as subfolder, in this case object can be empty
+      // we need this to differentiate subfolder create/delete from bucket create/delete
+      case S3Request(_, Some(s3path), None, accessType) if s3path.endsWith("/") && (accessType == Delete || accessType == Write) =>
+        isAuthorisedByRanger(s3path)
+
       // list-objects in the bucket operation
       case S3Request(_, Some(s3path), None, accessType) if accessType == Read || accessType == Head =>
         isAuthorisedByRanger(s3path)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -71,7 +71,7 @@ trait AuthorizationProviderRanger extends LazyLogging {
           false
       }
     }
-    //todo: check object conditions - last is always object? aws is not adding subdir unless object is passed?
+
     request match {
       // object operations, put / delete etc.
       case S3Request(_, Some(s3path), Some(_), _) =>

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceSpec.scala
@@ -65,7 +65,7 @@ class ProxyServiceSpec extends FlatSpec with DiagrammedAssertions with Scalatest
       assert(response == "Request not authenticated: " +
         "S3Request(" +
         "AwsRequestCredential(AwsAccessKey(notOkAccessKey),Some(AwsSessionToken(okSessionToken)))," +
-        "Some(okBucket)," +
+        "Some(/okBucket)," +
         "None," +
         "Read)")
     }

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
@@ -9,12 +9,17 @@ class S3RequestSpec extends FlatSpec with DiagrammedAssertions {
 
   "S3Request" should "parse an S3 request from an http Path and Method" in {
     val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.GET)
-    assert(result == S3Request(testCred, Some("demobucket"), None, Read))
+    assert(result == S3Request(testCred, Some("/demobucket"), None, Read))
   }
 
   it should "parse an S3 request from an http Path with object and Method" in {
     val result = S3Request(testCred, Uri.Path("/demobucket/demoobject"), HttpMethods.GET)
-    assert(result == S3Request(testCred, Some("demobucket"), Some("demoobject"), Read))
+    assert(result == S3Request(testCred, Some("/demobucket/demoobject"), Some("demoobject"), Read))
+  }
+
+  it should "parse an S3 request from an http Path with subfolder and Method" in {
+    val result = S3Request(testCred, Uri.Path("/demobucket/subfolder1/"), HttpMethods.GET)
+    assert(result == S3Request(testCred, Some("/demobucket/subfolder1/"), None, Read))
   }
 
   it should "parse none for bucket if path is only root" in {
@@ -29,7 +34,7 @@ class S3RequestSpec extends FlatSpec with DiagrammedAssertions {
 
   it should "set access to write for anything but GET" in {
     val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.POST)
-    assert(result == S3Request(testCred, Some("demobucket"), None, Write))
+    assert(result == S3Request(testCred, Some("/demobucket"), None, Write))
   }
 
 }


### PR DESCRIPTION
- changes bucket path naming to hdfs style with fqn (starting with / etc.)
- Adds option to check full s3 path in Ranger