### PR TITLE
add kerberos login

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,3 +299,14 @@ Commands can also be issued against the underlying RadosGW service:
     % aws --profile radosgw s3 ls
 
 The default profile can also be switched by modifying the `AWS_DEFAULT_PROFILE` environment variable.
+
+## Security environment
+
+For kerberos environment (e.g connecting to ranger) you need to provide keytab file and principle name.
+
+```bash
+AIRLOCK_KERBEROS_KEYTAB: "keytab_full_path"
+AIRLOCK_KERBEROS_PRINCIPAL: "user"
+```
+
+ 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,4 +32,9 @@ airlock {
         password = ${?AIRLOCK_ATLAS_PASSWORD}
         enabled = ${?AIRLOCK_ATLAS_ENABLED}
     }
+
+    kerberos {
+        keytab = ${?AIRLOCK_KERBEROS_KEYTAB}
+        principal = ${?AIRLOCK_KERBEROS_PRINCIPAL}
+    }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -40,6 +40,11 @@ airlock {
         password = "admin"
         enabled = false
     }
+
+    kerberos {
+        keytab = ""
+        principal = ""
+    }
 }
 
 akka {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/Server.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/Server.scala
@@ -3,15 +3,18 @@ package com.ing.wbaa.airlock.proxy
 import akka.actor.ActorSystem
 import com.ing.wbaa.airlock.proxy.config._
 import com.ing.wbaa.airlock.proxy.handler.RequestHandlerS3
-import com.ing.wbaa.airlock.proxy.provider.{ AuthenticationProviderSTS, AuthorizationProviderRanger, LineageProviderAtlas, SignatureProviderAws }
+import com.ing.wbaa.airlock.proxy.provider._
 
 object Server extends App {
 
-  new AirlockS3Proxy with AuthorizationProviderRanger with RequestHandlerS3 with AuthenticationProviderSTS with LineageProviderAtlas with SignatureProviderAws {
+  new AirlockS3Proxy with AuthorizationProviderRanger with RequestHandlerS3 with AuthenticationProviderSTS with LineageProviderAtlas with SignatureProviderAws with KerberosLoginProvider {
     override implicit lazy val system: ActorSystem = ActorSystem.create("airlock")
-    override val httpSettings = HttpSettings(system)
-    override val rangerSettings = RangerSettings(system)
-    override val storageS3Settings = StorageS3Settings(system)
+
+    override def kerberosSettings: KerberosSettings = KerberosSettings(system)
+
+    override val httpSettings: HttpSettings = HttpSettings(system)
+    override val rangerSettings: RangerSettings = RangerSettings(system)
+    override val storageS3Settings: StorageS3Settings = StorageS3Settings(system)
     override val stsSettings: StsSettings = StsSettings(system)
     override val atlasSettings: AtlasSettings = AtlasSettings(system)
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/config/KerberosSettings.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/config/KerberosSettings.scala
@@ -1,0 +1,14 @@
+package com.ing.wbaa.airlock.proxy.config
+
+import akka.actor.{ ExtendedActorSystem, Extension, ExtensionId, ExtensionIdProvider }
+import com.typesafe.config.Config
+
+class KerberosSettings(config: Config) extends Extension {
+  val keytab: String = config.getString("airlock.kerberos.keytab")
+  val principal: String = config.getString("airlock.kerberos.principal")
+}
+
+object KerberosSettings extends ExtensionId[KerberosSettings] with ExtensionIdProvider {
+  override def createExtension(system: ExtendedActorSystem): KerberosSettings = new KerberosSettings(system.settings.config)
+  override def lookup(): ExtensionId[KerberosSettings] = KerberosSettings
+}

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/KerberosLoginProvider.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/KerberosLoginProvider.scala
@@ -1,0 +1,39 @@
+package com.ing.wbaa.airlock.proxy.provider
+
+import java.io.File
+
+import com.ing.wbaa.airlock.proxy.config.KerberosSettings
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.lang.StringUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.UserGroupInformation
+
+import scala.util.{ Failure, Success, Try }
+
+
+trait KerberosLoginProvider extends LazyLogging {
+
+  protected[this] def kerberosSettings: KerberosSettings
+
+  loginUserFromKeytab(kerberosSettings.keytab, kerberosSettings.principal)
+
+  private def loginUserFromKeytab(keytab: String, principal: String): Unit = {
+
+    if (StringUtils.isNotBlank(keytab) && StringUtils.isNotBlank(principal)) {
+      if (!new File(keytab).exists()) {
+        logger.info("keytab file does not exist {}", keytab)
+      } else {
+        Try {
+          UserGroupInformation.setConfiguration(new Configuration())
+          UserGroupInformation.loginUserFromKeytab(principal, keytab)
+        } match {
+          case Success(_)         => logger.info("kerberos credentials provided {}", UserGroupInformation.getLoginUser)
+          case Failure(exception) => logger.error("kerberos login error {}", exception)
+        }
+      }
+    } else {
+      logger.info("kerberos credentials are not provided")
+    }
+  }
+
+}


### PR DESCRIPTION
1. to login there is a hadoop class  UserGroupInformation and method loginUserFromKeytab.
2. because in ranger we use RangerAdminRESTClient with getServicePoliciesIfUpdated there is MiscUtil.getUGILoginUser() which runs checkTGTAndReloginFromKeytab() on the UserGroupInformation - so the relogin is done in case of credentials expiration. 