### PR TITLE
Aws V2 signature is not properly handled

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.docker.ExecCmd
 import scalariform.formatter.preferences._
 
 name := "airlock"
-version := "0.1.2"
+version := "0.1.3"
 
 scalaVersion := "2.12.8"
 

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
@@ -148,16 +148,18 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
           withBucket(sdk) { testBucket =>
             withFile(1024 * 1024) { filename =>
               val testKeyFile = "keyPutFileByFile"
+              val destinationKey = "sdkcopy"
+              val ownerValue = "itTest"
               sdk.putObject(testBucket, testKeyFile, new File(filename))
 
-              val copyRequest = new CopyObjectRequest(testBucket, testKeyFile, testBucket, "sdkcopy")
+              val copyRequest = new CopyObjectRequest(testBucket, testKeyFile, testBucket, destinationKey)
               val newMetadata = new ObjectMetadata()
-              newMetadata.addUserMetadata("Owner", "itTest")
+              newMetadata.addUserMetadata("Owner", ownerValue)
               copyRequest.setMetadataDirective("REPLACE")
               copyRequest.setNewObjectMetadata(newMetadata)
 
-              val copyResult = sdk.copyObject(copyRequest)
-              assert(!copyResult.getETag.isEmpty)
+              sdk.copyObject(copyRequest)
+              assert(sdk.getObjectMetadata(testBucket, destinationKey).getUserMetadata.containsValue(ownerValue))
             }
           }
         }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
@@ -62,6 +62,10 @@ object ProxyDirectives extends LazyLogging {
         case Tuple1(optionalSessionToken) =>
           headerValue[AwsAccessKey](extractAuthorizationS3) tmap { case Tuple1(awsAccessKey) =>
 
+            val rootPath =
+              if (httpRequest.uri.path.endsWithSlash) httpRequest.uri.path.toString().dropRight(1)
+              else httpRequest.uri.path.toString()
+
             // aws is passing subdir in prefix parameter if no object is used, eg. list bucket objects
             val s3path = httpRequest.uri.rawQueryString match {
               case Some(queryString) if queryString.contains("prefix") =>
@@ -77,9 +81,9 @@ object ProxyDirectives extends LazyLogging {
                   }
 
                 if (queryPrefixPair.length == 2) {
-                  Uri.Path(s"${httpRequest.uri.path}/${queryPrefixPair.last.replace(delimiter, "/")}")
+                  Uri.Path(s"${rootPath}/${queryPrefixPair.last.replace(delimiter, "/")}")
                 } else {
-                  Uri.Path(s"${httpRequest.uri.path}")
+                  Uri.Path(s"${rootPath}")
                 }
               case _     => httpRequest.uri.path
             }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
@@ -34,7 +34,7 @@ trait RequestHandlerS3 extends LazyLogging with RadosGatewayHandler {
 
     fireRequestToS3(newRequest).flatMap { response =>
       if (response.status == StatusCodes.Forbidden && handleUserCreationRadosGw(userSTS)) fireRequestToS3(newRequest)
-      else Future.successful(response)
+      else Future.successful(response.withEntity(response.entity.withoutSizeLimit()))
     }
   }
 


### PR DESCRIPTION
Bug fixes for:
- incorrect extracting of s3path when path in request ends with slash
- adds missing x-aws-* headers for V2 signature process
- removes download limit for the client