### PR TITLE
Adds proper handling for bucket objects containing special characters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.docker.ExecCmd
 import scalariform.formatter.preferences._
 
 name := "airlock"
-version := "0.1.5"
+version := "0.1.6"
 
 scalaVersion := "2.12.8"
 

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
@@ -164,6 +164,33 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
           }
         }
 
+        "put objects with special characters in object names" in withS3SdkToMockProxy(awsSignerType) { sdk =>
+          withBucket(sdk) { testBucket =>
+            withFile(1024 * 1024) { filename =>
+              val testKeyFileWithDolar = "keywith$.txt"
+              val testKeyFileWithHash = "keywith#.txt"
+              val testKeyFileWithExclamation = "keywith!.txt"
+              val testKeyFileWithSpace = "keywith space.txt"
+              val testKeyFileWithBracket = "keywith[bracket].txt"
+              val testKeyFileWithPlus = "keywith+.txt"
+
+              val dolarUploadResult = sdk.putObject(testBucket, testKeyFileWithDolar, new File(filename))
+              val hashUploadResult = sdk.putObject(testBucket, testKeyFileWithHash, new File(filename))
+              val exclamationUploadResult = sdk.putObject(testBucket, testKeyFileWithExclamation, new File(filename))
+              val spaceUploadResult = sdk.putObject(testBucket, testKeyFileWithSpace, new File(filename))
+              val bracketUploadResult = sdk.putObject(testBucket, testKeyFileWithBracket, new File(filename))
+              val plusUploadResult = sdk.putObject(testBucket, testKeyFileWithPlus, new File(filename))
+
+              assert(!dolarUploadResult.getETag.isEmpty)
+              assert(!hashUploadResult.getETag.isEmpty)
+              assert(!exclamationUploadResult.getETag.isEmpty)
+              assert(!spaceUploadResult.getETag.isEmpty)
+              assert(!bracketUploadResult.getETag.isEmpty)
+              assert(!plusUploadResult.getETag.isEmpty)
+            }
+          }
+        }
+
         // TODO: Fix proxy for copyObject function
 //        "check if object can be copied" in withS3SdkToMockProxy(awsSignerType) { sdk =>
 //          withBucket(sdk) { testBucket =>

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
@@ -173,6 +173,7 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
               val testKeyFileWithSpace = "keywith space.txt"
               val testKeyFileWithBracket = "keywith[bracket].txt"
               val testKeyFileWithPlus = "keywith+.txt"
+              val testKeyFileWithCurly = "keywith(curly).txt"
 
               val dolarUploadResult = sdk.putObject(testBucket, testKeyFileWithDolar, new File(filename))
               val hashUploadResult = sdk.putObject(testBucket, testKeyFileWithHash, new File(filename))
@@ -180,6 +181,7 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
               val spaceUploadResult = sdk.putObject(testBucket, testKeyFileWithSpace, new File(filename))
               val bracketUploadResult = sdk.putObject(testBucket, testKeyFileWithBracket, new File(filename))
               val plusUploadResult = sdk.putObject(testBucket, testKeyFileWithPlus, new File(filename))
+              val curlyUploadResult = sdk.putObject(testBucket, testKeyFileWithCurly, new File(filename))
 
               assert(!dolarUploadResult.getETag.isEmpty)
               assert(!hashUploadResult.getETag.isEmpty)
@@ -187,6 +189,7 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
               assert(!spaceUploadResult.getETag.isEmpty)
               assert(!bracketUploadResult.getETag.isEmpty)
               assert(!plusUploadResult.getETag.isEmpty)
+              assert(!curlyUploadResult.getETag.isEmpty)
             }
           }
         }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -62,7 +62,8 @@ akka {
         server.transparent-head-requests = off
 
         # loosens parsing headers settings, letting us to parse AWS headers properly
-        server.raw-request-uri-header = off
+        # raw-request is used for AWS signature process, skip akka parsing
+        server.raw-request-uri-header = on
         server.parsing.modeled-header-parsing = off
         client.parsing.modeled-header-parsing = off
         client.user-agent-header = ""

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/aws/SignatureHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/aws/SignatureHelpers.scala
@@ -175,6 +175,12 @@ trait SignatureHelpers extends LazyLogging {
     }
   }
 
+  private def getResourcePathFromRequest(httpRequest: HttpRequest): String =
+    httpRequest.getHeader("Raw-Request-URI").isPresent match {
+      case true  => httpRequest.getHeader("Raw-Request-URI").get().value().split("\\?").head
+      case false => httpRequest.uri.path.toString()
+    }
+
   def getSignableRequest(
       httpRequest: HttpRequest,
       version: String,
@@ -189,7 +195,9 @@ trait SignatureHelpers extends LazyLogging {
       case _        => throw new Exception("Method not supported, request signature verification failed")
     })
 
-    request.setResourcePath(httpRequest.uri.path.toString())
+    val resourcePath = getResourcePathFromRequest(httpRequest)
+
+    request.setResourcePath(resourcePath)
     request.setEndpoint(new URI(s"http://${httpRequest.uri.authority.toString()}"))
 
     val requestParameters = extractRequestParameters(httpRequest, version)
@@ -203,18 +211,18 @@ trait SignatureHelpers extends LazyLogging {
             case (k, v)              => s"$k=${v.asScala.head}"
           }.mkString("&")
 
-        request.setResourcePath(httpRequest.uri.path.toString())
+        request.setResourcePath(resourcePath)
         request.setParameters(requestParameters)
         request.setContent(new ByteArrayInputStream(requestParamsCombined.getBytes()))
 
       case _ if !requestParameters.isEmpty =>
         logger.debug(s"Setting additional params for request $requestParameters")
 
-        request.setResourcePath(httpRequest.uri.path.toString())
+        request.setResourcePath(resourcePath)
         request.setParameters(requestParameters)
 
       case _ =>
-        request.setResourcePath(httpRequest.uri.path.toString())
+        request.setResourcePath(resourcePath)
     }
     request
   }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/aws/Signers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/aws/Signers.scala
@@ -10,6 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 // Instead of calculating hash on proxy we copy hash from client, otherwise we need to materialize body content
 sealed class CustomV4Signer() extends AWS4Signer with LazyLogging {
 
+  this.doubleUrlEncode = false
   override def calculateContentHash(request: SignableRequest[_]): String = request.getHeaders.get("X-Amz-Content-SHA256")
   override def sign(request: SignableRequest[_], credentials: AWSCredentials): Unit = super.sign(request, credentials)
 }


### PR DESCRIPTION
Since Ceph / S3 supports uploading objects with special characters in names, now
s3 objects with characters in name like #,!,$ etc. can be uplodad via Airlock