### PR TITLE
fileter list bucket objects based on ranger policies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ libraryDependencies ++= Seq(
     "net.manub"                    %% "scalatest-embedded-kafka" % "2.0.0" % IntegrationTest,
     "org.apache.ranger"            %  "ranger-plugins-common"  % "1.1.0" exclude("org.apache.kafka", "kafka_2.11"),
     "io.github.twonote"            %  "radosgw-admin4j"        % "1.0.2",
+    "com.lightbend.akka"           %% "akka-stream-alpakka-xml"% "1.0-M2",
     "com.typesafe.akka"            %% "akka-http-testkit"      % akkaVersion       % Test,
     "org.scalatest"                %% "scalatest"              % "3.0.5"           % "it,test",
     "com.amazonaws"                %  "aws-java-sdk-sts"       % "1.11.437"        % IntegrationTest

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.docker.ExecCmd
 import scalariform.formatter.preferences._
 
 name := "airlock"
-version := "0.1.8"
+version := "0.1.9"
 
 scalaVersion := "2.12.8"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: wbaa/airlock-dev-apache-ranger-postgres:0.0.13
 
   ranger-admin:
-    image: wbaa/airlock-dev-apache-ranger:0.0.15
+    image: wbaa/airlock-dev-apache-ranger:0.0.16
     stdin_open: true
     tty: true
     depends_on:
@@ -46,7 +46,7 @@ services:
     - "mariadb"
 
   keycloak:
-    image: wbaa/airlock-dev-keycloak:0.0.3
+    image: wbaa/airlock-dev-keycloak:0.0.4
     environment:
     - KEYCLOAK_USER=admin
     - KEYCLOAK_PASSWORD=admin

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/AirlockS3ProxyItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/AirlockS3ProxyItTest.scala
@@ -1,7 +1,6 @@
 package com.ing.wbaa.airlock.proxy
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.RemoteAddress
 import akka.http.scaladsl.model.Uri.{Authority, Host}
 import akka.stream.ActorMaterializer
 import com.amazonaws.auth.BasicSessionCredentials
@@ -62,7 +61,7 @@ class AirlockS3ProxyItTest extends AsyncWordSpec with DiagrammedAssertions
       override val atlasSettings: AtlasSettings = AtlasSettings(testSystem)
       override val kafkaSettings: KafkaSettings = KafkaSettings(testSystem)
 
-      override def isUserAuthorizedForRequest(request: S3Request, user: User, clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): Boolean = true
+      override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true
     }
     proxy.startup.flatMap { binding =>
       val authority = Authority(Host(binding.localAddress.getAddress), binding.localAddress.getPort)

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/AirlockS3ProxyItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/AirlockS3ProxyItTest.scala
@@ -4,15 +4,16 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.{Authority, Host}
 import akka.stream.ActorMaterializer
 import com.amazonaws.auth.BasicSessionCredentials
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService
 import com.amazonaws.services.securitytoken.model.GetSessionTokenRequest
 import com.ing.wbaa.airlock.proxy.config._
-import com.ing.wbaa.airlock.proxy.data._
-import com.ing.wbaa.airlock.proxy.handler.RequestHandlerS3
-import com.ing.wbaa.airlock.proxy.provider.{AuthenticationProviderSTS, LineageProviderAtlas, MessageProviderKafka, SignatureProviderAws}
+import com.ing.wbaa.airlock.proxy.data.{S3Request, User}
+import com.ing.wbaa.airlock.proxy.handler.{FilterRecursiveListBucketHandler, RequestHandlerS3}
+import com.ing.wbaa.airlock.proxy.provider._
 import com.ing.wbaa.testkit.AirlockFixtures
 import com.ing.wbaa.testkit.awssdk.{S3SdkHelpers, StsSdkHelpers}
-import com.ing.wbaa.testkit.oauth.OAuth2TokenRequest
+import com.ing.wbaa.testkit.oauth.{KeycloackToken, OAuth2TokenRequest}
 import org.scalatest.{Assertion, AsyncWordSpec, DiagrammedAssertions}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,9 +40,23 @@ class AirlockS3ProxyItTest extends AsyncWordSpec with DiagrammedAssertions
     override val httpBind: String = "127.0.0.1"
   }
 
-  private val validKeycloakCredentials = Map(
+  private val validKeycloakCredentialsTestuser = Map(
+    "grant_type" -> "password",
+    "username" -> "testuser",
+    "password" -> "password",
+    "client_id" -> "sts-airlock"
+  )
+
+  private val validKeycloakCredentialsUserone = Map(
     "grant_type" -> "password",
     "username" -> "userone",
+    "password" -> "password",
+    "client_id" -> "sts-airlock"
+  )
+
+  private val validKeycloakCredentialsUsertwo = Map(
+    "grant_type" -> "password",
+    "username" -> "usertwo",
     "password" -> "password",
     "client_id" -> "sts-airlock"
   )
@@ -53,7 +68,9 @@ class AirlockS3ProxyItTest extends AsyncWordSpec with DiagrammedAssertions
     * @return Future[Assertion]
     */
   def withSdkToMockProxy(testCode: (AWSSecurityTokenService, Authority) => Future[Assertion]): Future[Assertion] = {
-    val proxy: AirlockS3Proxy = new AirlockS3Proxy with RequestHandlerS3 with AuthenticationProviderSTS with LineageProviderAtlas with SignatureProviderAws with MessageProviderKafka {
+    val proxy: AirlockS3Proxy = new AirlockS3Proxy with RequestHandlerS3
+      with FilterRecursiveListBucketHandler with AuthenticationProviderSTS
+      with AuthorizationProviderRanger with LineageProviderAtlas with SignatureProviderAws with MessageProviderKafka {
       override implicit lazy val system: ActorSystem = testSystem
       override val httpSettings: HttpSettings = airlockHttpSettings
       override val storageS3Settings: StorageS3Settings = StorageS3Settings(testSystem)
@@ -61,7 +78,14 @@ class AirlockS3ProxyItTest extends AsyncWordSpec with DiagrammedAssertions
       override val atlasSettings: AtlasSettings = AtlasSettings(testSystem)
       override val kafkaSettings: KafkaSettings = KafkaSettings(testSystem)
 
-      override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true
+      override protected def rangerSettings: RangerSettings = RangerSettings(testSystem)
+
+      override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = {
+        user match {
+          case User(userName, _, _, _) if userName.value == "testuser" => true
+          case _ => super.isUserAuthorizedForRequest(request, user)
+        }
+      }
     }
     proxy.startup.flatMap { binding =>
       val authority = Authority(Host(binding.localAddress.getAddress), binding.localAddress.getPort)
@@ -70,22 +94,42 @@ class AirlockS3ProxyItTest extends AsyncWordSpec with DiagrammedAssertions
     }
   }
 
+  private def getSdk(stsSdk: AWSSecurityTokenService, s3ProxyAuthority: Authority, keycloakToken: KeycloackToken): AmazonS3 = {
+    val cred = stsSdk.getSessionToken(new GetSessionTokenRequest()
+      .withTokenCode(keycloakToken.access_token))
+      .getCredentials
+
+    val sessionCredentials = new BasicSessionCredentials(
+      cred.getAccessKeyId,
+      cred.getSecretAccessKey,
+      cred.getSessionToken
+    )
+
+    getAmazonS3("S3SignerType", s3ProxyAuthority, sessionCredentials)
+  }
+
   "Airlock" should {
-    "connect to ceph with credentials from STS (GetSessionToken)" in withSdkToMockProxy { (stsSdk, s3ProxyAuthority) =>
-      retrieveKeycloackToken(validKeycloakCredentials).map { keycloakToken =>
-        val cred = stsSdk.getSessionToken(new GetSessionTokenRequest()
-          .withTokenCode(keycloakToken.access_token))
-          .getCredentials
-
-        val sessionCredentials = new BasicSessionCredentials(
-          cred.getAccessKeyId,
-          cred.getSecretAccessKey,
-          cred.getSessionToken
-        )
-
-        val s3Sdk = getAmazonS3("S3SignerType", s3ProxyAuthority, sessionCredentials)
-        withBucket(s3Sdk) { testBucket =>
-          assert(s3Sdk.listBuckets().asScala.toList.map(_.getName).contains(testBucket))
+    "create a home bucket and files for userone and user two - users can see only own objects" in withSdkToMockProxy { (stsSdk, s3ProxyAuthority) =>
+      retrieveKeycloackToken(validKeycloakCredentialsTestuser).flatMap { keycloakTokenTestuser =>
+        val testuserS3 = getSdk(stsSdk, s3ProxyAuthority, keycloakTokenTestuser)
+        val objectForAll = List("mainfile")
+        val userOneObjects = List("userone/", "userone/dir1/", "userone/dir1/file1")
+        val userTwoObjects = List("usertwo/", "usertwo/dir2/", "usertwo/dir2/file2")
+        withHomeBucket(testuserS3, objectForAll ++ userOneObjects ++ userTwoObjects) { bucket =>
+          retrieveKeycloackToken(validKeycloakCredentialsUserone).map { keycloakToken =>
+            val useroneS3 = getSdk(stsSdk, s3ProxyAuthority, keycloakToken)
+            val returnedObjects = useroneS3.listObjects(bucket).getObjectSummaries.asScala.toList.map(_.getKey)
+            objectForAll.foreach(obj => assert(returnedObjects.contains(obj)))
+            userOneObjects.foreach(obj => assert(returnedObjects.contains(obj)))
+            assert(returnedObjects.size == 4)
+          }
+          retrieveKeycloackToken(validKeycloakCredentialsUsertwo).map { keycloakToken =>
+            val usertwoS3 = getSdk(stsSdk, s3ProxyAuthority, keycloakToken)
+            val returnedObjects = usertwoS3.listObjects(bucket).getObjectSummaries.asScala.toList.map(_.getKey)
+            objectForAll.foreach(obj => assert(returnedObjects.contains(obj)))
+            userTwoObjects.foreach(obj => assert(returnedObjects.contains(obj)))
+            assert(returnedObjects.size == 4)
+          }
         }
       }
     }

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
@@ -37,7 +37,8 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
     * @return Assertion
     */
   def withS3SdkToMockProxy(awsSignerType: String)(testCode: AmazonS3 => Assertion): Future[Assertion] = {
-    val proxy: AirlockS3Proxy = new AirlockS3Proxy with RequestHandlerS3 with SignatureProviderAws with MessageProviderKafka {
+    val proxy: AirlockS3Proxy = new AirlockS3Proxy with RequestHandlerS3 with SignatureProviderAws
+      with FilterRecursiveListBucketHandler with MessageProviderKafka {
       override implicit lazy val system: ActorSystem = testSystem
       override val httpSettings: HttpSettings = airlockHttpSettings
       override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3ItTest.scala
@@ -40,7 +40,7 @@ class RequestHandlerS3ItTest extends AsyncWordSpec with DiagrammedAssertions wit
     val proxy: AirlockS3Proxy = new AirlockS3Proxy with RequestHandlerS3 with SignatureProviderAws with MessageProviderKafka {
       override implicit lazy val system: ActorSystem = testSystem
       override val httpSettings: HttpSettings = airlockHttpSettings
-      override def isUserAuthorizedForRequest(request: S3Request, user: User, clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): Boolean = true
+      override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true
       override val storageS3Settings: StorageS3Settings = StorageS3Settings(testSystem)
       override val atlasSettings: AtlasSettings = AtlasSettings(testSystem)
       override val kafkaSettings: KafkaSettings = KafkaSettings(testSystem)

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -55,130 +55,130 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
   "Authorization Provider Ranger" should {
     "authorize a request" that {
       "successfully authorizes a request on a bucket" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs)), user))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs), user))
       }
 
       "successfully authorizes a request on an object in a bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = Some("object"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "authorize for requests without bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None,
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "doesn't authorize for requests that are not supposed to be (Write)" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write, s3Object = Some("object"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "doesn't authorize for unauthorized user and group" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs)), user.copy(
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs), user.copy(
           userName = UserName("unauthorized"), userGroups = Set(UserGroup("unauthorized")))))
       }
 
       "does authorize for unauthorized user but authorized group" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs)), user.copy(userName = UserName("unauthorized"))))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs), user.copy(userName = UserName("unauthorized"))))
       }
 
       "does authorize for authorized user but unauthorized group" in withAuthorizationProviderRanger() { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs)), user.copy(userGroups = Set(UserGroup("unauthorized")))))
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs), user.copy(userGroups = Set(UserGroup("unauthorized")))))
       }
 
       "authorize allow-list-buckets with default settings" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None,
-          accessType = Read, clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          accessType = Read, clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize allow-list-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val listBucketsEnabled: Boolean = true
       }) { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None,
-          accessType = Read, clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          accessType = Read, clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize allow-create-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Write,
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize delete buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Delete,
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "doesn't authorize when method is not REST (GET, PUT, DELETE etc.)" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = NoAccess,
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "doesn't authorize when remoteIpAddress is in a DENY policy" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(unauthorizedIPAddress),
-          headerIPs = Some(headerIPs)), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = unauthorizedIPAddress,
+          headerIPs = headerIPs), user))
       }
 
       "doesn't authorize when X-Real-IP is in a DENY policy" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs.copy(`X-Real-IP` = Some(unauthorizedIPAddress)))), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs.copy(`X-Real-IP` = Some(unauthorizedIPAddress))), user))
       }
 
       "doesn't authorize when any of X-Forwarded-For is in a DENY policy" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs.copy(`X-Forwarded-For` = Some(headerIPs.`X-Forwarded-For`.get :+ unauthorizedIPAddress)))), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs.copy(`X-Forwarded-For` = Some(headerIPs.`X-Forwarded-For`.get :+ unauthorizedIPAddress))), user))
       }
 
       "doesn't authorize when Remote-Address is in a DENY policy" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(unauthorizedIPAddress)))), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs.copy(`Remote-Address` = Some(unauthorizedIPAddress))), user))
       }
 
       "doesn't authorize when any IP is unknown" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(RemoteAddress.Unknown), headerIPs = Some(headerIPs)), user))
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = Some(clientIPAddress),
-          headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = RemoteAddress.Unknown, headerIPs = headerIPs), user))
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(clientIPAddress = clientIPAddress,
+          headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "doesn't allow listing subdir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/demobucket/subdir"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "does allow read homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/home/testuser"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "doesn't allow read in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/home/testuser1"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "does allow write homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(
           s3Request.copy(s3BucketPath = Some("/home/testuser"), s3Object = Some("object1"),
-            accessType = Write, clientIPAddress = Some(clientIPAddress),
-            headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+            accessType = Write, clientIPAddress = clientIPAddress,
+            headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "doesn't allow write in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(
           s3Request.copy(s3BucketPath = Some("/home/testuser1"), s3Object = Some("object1"),
-            accessType = Write, clientIPAddress = Some(clientIPAddress),
-            headerIPs = Some(headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown)))), user))
+            accessType = Write, clientIPAddress = clientIPAddress,
+            headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "does allow read all user dir" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some("/home"),
-          clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs)), user))
+          clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
     }
   }

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
@@ -24,7 +24,7 @@ class MessageProviderKafkaItTest extends WordSpecLike with DiagrammedAssertions 
   override implicit val executionContext: ExecutionContext = testSystem.dispatcher
 
   val s3Request = S3Request(AwsRequestCredential(AwsAccessKey("a"), None), Some("demobucket"), Some("s3object"), Read)
-  val remoteClientIP = RemoteAddress(InetAddress.getByName("127.0.0.1"))
+    .copy(clientIPAddress = Some(RemoteAddress(InetAddress.getByName("127.0.0.1"))))
 
   "KafkaMessageProvider" should {
     "Send message to correct topic with Put or Post" in {
@@ -34,7 +34,7 @@ class MessageProviderKafkaItTest extends WordSpecLike with DiagrammedAssertions 
         val createEventsTopic = "create_events"
         createCustomTopic(createEventsTopic)
 
-        emitEvent(s3Request, HttpMethods.PUT, "testUser", remoteClientIP)
+        emitEvent(s3Request, HttpMethods.PUT, "testUser")
         val result = consumeFirstStringMessageFrom(createEventsTopic)
         assert(result.contains("s3:ObjectCreated:PUT"))
       }
@@ -47,13 +47,13 @@ class MessageProviderKafkaItTest extends WordSpecLike with DiagrammedAssertions 
         val deleteEventsTopic = "delete_events"
         createCustomTopic(deleteEventsTopic)
 
-        emitEvent(s3Request, HttpMethods.DELETE, "testUser", remoteClientIP)
+        emitEvent(s3Request, HttpMethods.DELETE, "testUser")
         assert(consumeFirstStringMessageFrom(deleteEventsTopic).contains("s3:ObjectRemoved:DELETE"))
       }
     }
 
     "fail on incomplete data" in {
-      recoverToSucceededIf[Exception](emitEvent(s3Request.copy(s3Object = None), HttpMethods.PUT, "testUser", remoteClientIP))
+      recoverToSucceededIf[Exception](emitEvent(s3Request.copy(s3Object = None), HttpMethods.PUT, "testUser"))
     }
   }
 

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
@@ -24,7 +24,7 @@ class MessageProviderKafkaItTest extends WordSpecLike with DiagrammedAssertions 
   override implicit val executionContext: ExecutionContext = testSystem.dispatcher
 
   val s3Request = S3Request(AwsRequestCredential(AwsAccessKey("a"), None), Some("demobucket"), Some("s3object"), Read)
-    .copy(clientIPAddress = Some(RemoteAddress(InetAddress.getByName("127.0.0.1"))))
+    .copy(clientIPAddress = RemoteAddress(InetAddress.getByName("127.0.0.1")))
 
   "KafkaMessageProvider" should {
     "Send message to correct topic with Put or Post" in {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/Server.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/Server.scala
@@ -2,12 +2,12 @@ package com.ing.wbaa.airlock.proxy
 
 import akka.actor.ActorSystem
 import com.ing.wbaa.airlock.proxy.config._
-import com.ing.wbaa.airlock.proxy.handler.RequestHandlerS3
+import com.ing.wbaa.airlock.proxy.handler.{ FilterRecursiveListBucketHandler, RequestHandlerS3 }
 import com.ing.wbaa.airlock.proxy.provider._
 
 object Server extends App {
 
-  new AirlockS3Proxy with AuthorizationProviderRanger with RequestHandlerS3 with AuthenticationProviderSTS with LineageProviderAtlas with SignatureProviderAws with KerberosLoginProvider with MessageProviderKafka {
+  new AirlockS3Proxy with AuthorizationProviderRanger with RequestHandlerS3 with AuthenticationProviderSTS with LineageProviderAtlas with SignatureProviderAws with KerberosLoginProvider with FilterRecursiveListBucketHandler with MessageProviderKafka {
     override implicit lazy val system: ActorSystem = ActorSystem.create("airlock")
 
     override def kerberosSettings: KerberosSettings = KerberosSettings(system)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/PostRequestActions.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/PostRequestActions.scala
@@ -14,7 +14,7 @@ trait PostRequestActions {
 
   protected[this] def createLineageFromRequest(httpRequest: HttpRequest, userSTS: User, clientIPAddress: RemoteAddress): Future[LineageResponse]
 
-  protected[this] def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String, clientIPAddress: RemoteAddress): Future[Done]
+  protected[this] def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String): Future[Done]
 
   def createAtlasLineage(response: HttpResponse, httpRequest: HttpRequest, userSTS: User, clientIPAddress: RemoteAddress): Unit =
     if (atlasSettings.atlasEnabled && (response.status == StatusCodes.OK || response.status == StatusCodes.NoContent))
@@ -22,16 +22,16 @@ trait PostRequestActions {
       createLineageFromRequest(httpRequest, userSTS, clientIPAddress)
 
   protected[this] def createBucketNotification(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request,
-      userSTS: User, clientIPAddress: RemoteAddress): Future[Done] =
+      userSTS: User): Future[Done] =
     httpRequest.method match {
       case HttpMethods.POST | HttpMethods.PUT | HttpMethods.DELETE if kafkaSettings.kafkaEnabled && (response.status == StatusCodes.OK || response.status == StatusCodes.NoContent) =>
-        emitEvent(s3Request, httpRequest.method, userSTS.userName.value, clientIPAddress)
+        emitEvent(s3Request, httpRequest.method, userSTS.userName.value)
       case _ => Future.successful(Done)
     }
 
-  protected[this] def handlePostRequestActions(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request, userSTS: User, clientIPAddress: RemoteAddress): Unit = {
-    createAtlasLineage(response, httpRequest, userSTS, clientIPAddress)
-    createBucketNotification(response, httpRequest, s3Request, userSTS, clientIPAddress)
+  protected[this] def handlePostRequestActions(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request, userSTS: User): Unit = {
+    createAtlasLineage(response, httpRequest, userSTS, s3Request.clientIPAddress.get)
+    createBucketNotification(response, httpRequest, s3Request, userSTS)
   }
 
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/PostRequestActions.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/PostRequestActions.scala
@@ -30,7 +30,7 @@ trait PostRequestActions {
     }
 
   protected[this] def handlePostRequestActions(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request, userSTS: User): Unit = {
-    createAtlasLineage(response, httpRequest, userSTS, s3Request.clientIPAddress.get)
+    createAtlasLineage(response, httpRequest, userSTS, s3Request.clientIPAddress)
     createBucketNotification(response, httpRequest, s3Request, userSTS)
   }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
@@ -48,7 +48,8 @@ trait ProxyService extends LazyLogging {
             onComplete(areCredentialsActive(s3Request.credential)) {
               case Success(Some(userSTS: User)) =>
                 logger.debug(s"Credentials active for request, user retrieved: $userSTS")
-                processRequestForValidUser(httpRequest, s3Request, userSTS)
+                val fullS3Request = s3Request.copy(clientIPAddress = Some(clientIPAddress), headerIPs = Some(headerIPs))
+                processRequestForValidUser(httpRequest, fullS3Request, userSTS)
               case Success(None) =>
                 val msg = s"Request not authenticated: $s3Request"
                 logger.warn(msg)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBuckets.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBuckets.scala
@@ -1,10 +1,10 @@
 package com.ing.wbaa.airlock.proxy.api
 
 import akka.http.scaladsl.marshallers.xml.ScalaXmlSupport
-import akka.http.scaladsl.model.{ HttpRequest, RemoteAddress }
+import akka.http.scaladsl.model.{ HttpRequest }
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import com.ing.wbaa.airlock.proxy.data.{ Read, S3Request, User }
-import akka.http.scaladsl.server.Directives._
 
 import scala.xml.NodeSeq
 
@@ -17,12 +17,12 @@ trait ProxyServiceWithListAllBuckets extends ProxyService with ScalaXmlSupport {
 
   protected[this] def listAllBuckets: Seq[String]
 
-  override protected[this] def processAuthorizedRequest(httpRequest: HttpRequest, s3Request: S3Request, userSTS: User, clientIPAddress: RemoteAddress): Route = {
+  override protected[this] def processAuthorizedRequest(httpRequest: HttpRequest, s3Request: S3Request, userSTS: User): Route = {
     s3Request match {
       //only when list buckets is requested we show all buckets
-      case S3Request(_, None, None, accessType) if accessType == Read =>
+      case S3Request(_, None, None, accessType, _, _) if accessType == Read =>
         complete(getListAllMyBucketsXml())
-      case _ => super.processAuthorizedRequest(httpRequest, s3Request, userSTS, clientIPAddress)
+      case _ => super.processAuthorizedRequest(httpRequest, s3Request, userSTS)
     }
   }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/directive/ProxyDirectives.scala
@@ -85,7 +85,7 @@ object ProxyDirectives extends LazyLogging {
                 } else {
                   Uri.Path(s"${rootPath}")
                 }
-              case _     => httpRequest.uri.path
+              case _     => Uri.Path(s"${rootPath}")
             }
 
             val s3Request = S3Request(

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
@@ -1,5 +1,6 @@
 package com.ing.wbaa.airlock.proxy.data
 
+import akka.http.scaladsl.model.RemoteAddress.Unknown
 import akka.http.scaladsl.model.{ HttpMethod, RemoteAddress }
 import akka.http.scaladsl.model.Uri.Path
 import com.typesafe.scalalogging.LazyLogging
@@ -16,8 +17,8 @@ case class S3Request(
     s3BucketPath: Option[String],
     s3Object: Option[String],
     accessType: AccessType,
-    clientIPAddress: Option[RemoteAddress] = None,
-    headerIPs: Option[HeaderIPs] = None
+    clientIPAddress: RemoteAddress = Unknown,
+    headerIPs: HeaderIPs = HeaderIPs()
 )
 
 object S3Request extends LazyLogging {
@@ -28,7 +29,8 @@ object S3Request extends LazyLogging {
       Some(pathString.split("/").last)
     }
 
-  def apply(credential: AwsRequestCredential, path: Path, httpMethod: HttpMethod): S3Request = {
+  def apply(credential: AwsRequestCredential, path: Path, httpMethod: HttpMethod,
+      clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): S3Request = {
 
     val pathString = path.toString()
     val s3path = if (path.length > 1) { Some(pathString) } else { None }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
@@ -1,6 +1,6 @@
 package com.ing.wbaa.airlock.proxy.data
 
-import akka.http.scaladsl.model.HttpMethod
+import akka.http.scaladsl.model.{ HttpMethod, RemoteAddress }
 import akka.http.scaladsl.model.Uri.Path
 import com.typesafe.scalalogging.LazyLogging
 
@@ -15,7 +15,9 @@ case class S3Request(
     credential: AwsRequestCredential,
     s3BucketPath: Option[String],
     s3Object: Option[String],
-    accessType: AccessType
+    accessType: AccessType,
+    clientIPAddress: Option[RemoteAddress] = None,
+    headerIPs: Option[HeaderIPs] = None
 )
 
 object S3Request extends LazyLogging {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandler.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandler.scala
@@ -1,0 +1,130 @@
+package com.ing.wbaa.airlock.proxy.handler
+
+import java.net.URLDecoder
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse }
+import akka.stream.alpakka.xml.scaladsl.{ XmlParsing, XmlWriting }
+import akka.stream.alpakka.xml.{ EndElement, ParseEvent, StartElement, TextEvent }
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+import com.ing.wbaa.airlock.proxy.data.{ Read, S3Request, User }
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.collection.immutable
+import scala.collection.mutable.ListBuffer
+
+trait FilterRecursiveListBucketHandler extends LazyLogging {
+
+  protected[this] def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean
+
+  /**
+   * for list objects in bucket we need filter response when --recursive is set
+   * --recursive means that there is a delimiter param in request query and the access type is READ
+   *
+   * @param request
+   * @param userSTS
+   * @param s3request
+   * @param response
+   * @return for recursive request it returns filtered response for others the original response
+   */
+  protected[this] def filterResponse(request: HttpRequest, userSTS: User, s3request: S3Request, response: HttpResponse): HttpResponse = {
+    val isNoDelimiterParamAndIsReadAccess =
+      !request.uri.rawQueryString.getOrElse("").contains("delimiter") && s3request.accessType == Read && s3request.s3Object.isEmpty
+    if (isNoDelimiterParamAndIsReadAccess) {
+      response.transformEntityDataBytes(filterRecursiveListObjects(userSTS, s3request))
+    } else {
+      response
+    }
+  }
+
+  /**
+   * Xml as byte of steam is parsed and each value of <Key> tags is checked if the user is authorised for it.
+   *
+   * @param user
+   * @param requestS3
+   * @return xml as stream of bytes with only authorised resources
+   */
+  protected[this] def filterRecursiveListObjects(user: User, requestS3: S3Request): Flow[ByteString, ByteString, NotUsed] = {
+    def elementResult(allContentsElements: ListBuffer[ParseEvent], isContentsTag: Boolean, element: ParseEvent): immutable.Seq[ParseEvent] = {
+      if (isContentsTag) {
+        allContentsElements += element
+        immutable.Seq.empty
+      } else {
+        immutable.Seq(element)
+      }
+    }
+
+    def isPathOkInRangerPolicy(path: String): Boolean = {
+      val pathToCheck = normalizePath(path)
+      val isUserAuthorized = isUserAuthorizedForRequest(requestS3.copy(s3BucketPath = Some(pathToCheck)), user)
+      logger.debug("user {} isUserAuthorized for path {} = {}", user.userName, pathToCheck, isUserAuthorized)
+      isUserAuthorized
+    }
+
+    /**
+     * ei file => dir/dir2
+     * ei dir%2Fdir2%2F => dir/dir2
+     * ei dir%2Fdir2%2Ffile => dir/dir2
+     *
+     * @param path
+     * @return decoded path without last slash or last object
+     */
+    def normalizePath(path: String): String = {
+      val delimiter = "/"
+      val decodedPath = URLDecoder.decode(path, "UTF-8")
+      val delimiterIndex = decodedPath.lastIndexOf(delimiter)
+      val pathToCheck = if (delimiterIndex > 0) delimiter + decodedPath.substring(0, delimiterIndex) else ""
+      val s3path = requestS3.s3BucketPath.getOrElse(delimiter)
+      val s3pathWithoutLastDelimiter = if (s3path.length > 1 && s3path.endsWith(delimiter)) s3path.substring(0, s3path.length - 1) else s3path
+      s3pathWithoutLastDelimiter + pathToCheck
+    }
+
+    Flow[ByteString].via(XmlParsing.parser)
+      .statefulMapConcat(() => {
+        // state
+        val keyTagValue = StringBuilder.newBuilder
+        val allContentsElements = new ListBuffer[ParseEvent]
+        var isContentsTag = false
+        var isKeyTag = false
+
+        // aggregation function
+        parseEvent =>
+          parseEvent match {
+            //catch <Contents> to start collecting elements
+            case element: StartElement if element.localName == "Contents" =>
+              isContentsTag = true
+              allContentsElements.clear()
+              allContentsElements += element
+              immutable.Seq.empty
+            //catch end </Contents> to validate the path in ranger
+            case element: EndElement if element.localName == "Contents" =>
+              isContentsTag = false
+              allContentsElements += element
+              if (isPathOkInRangerPolicy(keyTagValue.stripMargin)) {
+                allContentsElements.toList
+              } else {
+                immutable.Seq.empty
+              }
+            // catch <Key> where is the patch name to match in ranger
+            case element: StartElement if element.localName == "Key" =>
+              keyTagValue.clear()
+              isKeyTag = true
+              elementResult(allContentsElements, isContentsTag, element)
+            //catch end </Key>
+            case element: EndElement if element.localName == "Key" =>
+              isKeyTag = false
+              elementResult(allContentsElements, isContentsTag, element)
+            //catch all element text <..>text<\..> but only set the text from <Key>
+            case element: TextEvent =>
+              if (isKeyTag) keyTagValue.append(element.text)
+              elementResult(allContentsElements, isContentsTag, element)
+            //just past through the rest of elements
+            case element =>
+              elementResult(allContentsElements, isContentsTag, element)
+          }
+      })
+      .via(XmlWriting.writer)
+  }
+
+}

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
@@ -1,34 +1,26 @@
 package com.ing.wbaa.airlock.proxy.handler
 
-import java.net.URLDecoder
-
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
-import akka.stream.alpakka.xml.{ EndElement, ParseEvent, StartElement, TextEvent }
-import akka.stream.alpakka.xml.scaladsl.{ XmlParsing, XmlWriting }
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
 import com.ing.wbaa.airlock.proxy.config.StorageS3Settings
-import com.ing.wbaa.airlock.proxy.data.{ Read, S3Request, User }
+import com.ing.wbaa.airlock.proxy.data.{ S3Request, User }
 import com.ing.wbaa.airlock.proxy.handler.radosgw.RadosGatewayHandler
 import com.typesafe.scalalogging.LazyLogging
 
-import scala.collection.{ immutable, mutable }
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Success
 
 trait RequestHandlerS3 extends LazyLogging with RadosGatewayHandler {
 
   protected[this] implicit def system: ActorSystem
+
   protected[this] implicit def executionContext: ExecutionContext
 
   protected[this] def storageS3Settings: StorageS3Settings
 
-  protected[this] def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean
+  protected[this] def filterResponse(request: HttpRequest, userSTS: User, s3request: S3Request, response: HttpResponse): HttpResponse
 
   /**
    * Updates the URI for S3 and sends the request to S3.
@@ -64,101 +56,5 @@ trait RequestHandlerS3 extends LazyLogging with RadosGatewayHandler {
       .singleRequest(request)
       .andThen { case Success(r) => logger.debug(s"Received response from Ceph: ${r.status}") }
       .map(r => r.withEntity(r.entity.withoutSizeLimit()))
-  }
-
-  /**
-   * for list objects in bucket we need filter response when --recursive is set
-   * --recursive means that there is a delimiter param in request query and the access type is READ
-   * @param request
-   * @param userSTS
-   * @param s3request
-   * @param response
-   * @return for recursive request it returns filtered response for others the original response
-   */
-  protected[this] def filterResponse(request: HttpRequest, userSTS: User, s3request: S3Request, response: HttpResponse): HttpResponse = {
-    val isNoDelimiterParamAndIsReadAccess =
-      !request.uri.rawQueryString.getOrElse("").contains("delimiter") && s3request.accessType == Read && s3request.s3Object.isEmpty
-    if (isNoDelimiterParamAndIsReadAccess) {
-      response.transformEntityDataBytes(filterRecursiveListObjects(userSTS, s3request))
-    } else {
-      response
-    }
-  }
-
-  /**
-   * Xml as byte of steam is parsed and each value of <Key> tags is checked if the user is authorised for it.
-   * @param user
-   * @param requestS3
-   * @return xml as stream of bytes with only authorised resources
-   */
-  protected[this] def filterRecursiveListObjects(user: User, requestS3: S3Request): Flow[ByteString, ByteString, NotUsed] = {
-    def elementResult(allContentsElements: ListBuffer[ParseEvent], isContentsTag: Boolean, element: ParseEvent): immutable.Seq[ParseEvent] = {
-      if (isContentsTag) {
-        allContentsElements += element
-        immutable.Seq.empty
-      } else {
-        immutable.Seq(element)
-      }
-    }
-
-    val rangerAuthorizedFalseCache = mutable.Map.empty[String, Boolean]
-
-    def isPathOkInRangerPolicy(path: String): Boolean = {
-      val pathToCheck = normalizePath(path)
-      val isUserAuthorized = isUserAuthorizedForRequest(requestS3.copy(s3BucketPath = Some(pathToCheck)), user)
-      logger.debug("user {} isUserAuthorized for path {} = {}", user.userName, pathToCheck, isUserAuthorized)
-      if (!isUserAuthorized) rangerAuthorizedFalseCache.put(path, isUserAuthorized)
-      isUserAuthorized
-    }
-
-    def normalizePath(path: String): String = {
-      val delimiter = "/"
-      val decodedPath = URLDecoder.decode(path, "UTF-8")
-      val delimiterIndex = decodedPath.lastIndexOf(delimiter)
-      val pathToCheck = if (delimiterIndex > 0) delimiter + decodedPath.substring(0, delimiterIndex) else ""
-      val s3path = requestS3.s3BucketPath.getOrElse(delimiter)
-      val s3pathWithoutLastDelimiter = if (s3path.length > 1 && s3path.endsWith(delimiter)) s3path.substring(0, s3path.length - 1) else s3path
-      s3pathWithoutLastDelimiter + pathToCheck
-    }
-
-    Flow[ByteString].via(XmlParsing.parser)
-      .statefulMapConcat(() => {
-        // state
-        val keyTagValue = StringBuilder.newBuilder
-        val allContentsElements = new ListBuffer[ParseEvent]
-        var isContentsTag = false
-        var isKeyTag = false
-
-        // aggregation function
-        parseEvent =>
-          parseEvent match {
-            case element: StartElement if element.localName == "Contents" =>
-              isContentsTag = true
-              allContentsElements.clear()
-              allContentsElements += element
-              immutable.Seq.empty
-            case element: EndElement if element.localName == "Contents" =>
-              isContentsTag = false
-              allContentsElements += element
-              if (isPathOkInRangerPolicy(keyTagValue.stripMargin)) {
-                allContentsElements.toList
-              } else {
-                immutable.Seq.empty
-              }
-            case element: StartElement if element.localName == "Key" =>
-              keyTagValue.clear()
-              isKeyTag = true
-              elementResult(allContentsElements, isContentsTag, element)
-            case element: EndElement if element.localName == "Key" =>
-              isKeyTag = false
-              elementResult(allContentsElements, isContentsTag, element)
-            case element: TextEvent =>
-              if (isKeyTag) keyTagValue.append(element.text)
-              elementResult(allContentsElements, isContentsTag, element)
-            case s =>
-              elementResult(allContentsElements, isContentsTag, s)
-          }
-      })
-      .via(XmlWriting.writer)
   }
 }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3.scala
@@ -117,7 +117,7 @@ trait RequestHandlerS3 extends LazyLogging with RadosGatewayHandler {
       val delimiterIndex = decodedPath.lastIndexOf(delimiter)
       val pathToCheck = if (delimiterIndex > 0) delimiter + decodedPath.substring(0, delimiterIndex) else ""
       val s3path = requestS3.s3BucketPath.getOrElse(delimiter)
-      val s3pathWithoutLastDelimiter = (if (s3path.length > 1 && s3path.endsWith(delimiter)) s3path.substring(0, s3path.length - 1) else s3path) + pathToCheck
+      val s3pathWithoutLastDelimiter = if (s3path.length > 1 && s3path.endsWith(delimiter)) s3path.substring(0, s3path.length - 1) else s3path
       s3pathWithoutLastDelimiter + pathToCheck
     }
 

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRanger.scala
@@ -61,8 +61,8 @@ trait AuthorizationProviderRanger extends LazyLogging {
       // We're using the original client's IP address for verification in Ranger. Ranger seems to use the
       // RemoteIPAddress variable for this. For the header IPs we use the ForwardedAddresses: this is not
       // completely true, but it works fairly enough.
-      rangerRequest.setRemoteIPAddress(request.clientIPAddress.map(_.toOption.map(_.getHostAddress).orNull).orNull)
-      rangerRequest.setForwardedAddresses(request.headerIPs.map(_.allIPs.map(_.toOption.map(_.getHostAddress).orNull)).orNull.asJava)
+      rangerRequest.setRemoteIPAddress(request.clientIPAddress.toOption.map(_.getHostAddress).orNull)
+      rangerRequest.setForwardedAddresses(request.headerIPs.allIPs.map(_.toOption.map(_.getHostAddress).orNull).asJava)
 
       logger.debug(s"Checking ranger with request: $rangerRequest")
       Try { rangerPlugin.isAccessAllowed(rangerRequest).getIsAllowed } match {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafka.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafka.scala
@@ -1,10 +1,10 @@
 package com.ing.wbaa.airlock.proxy.provider
 
 import akka.Done
+import akka.http.scaladsl.model.{ HttpMethod, HttpMethods }
 import com.ing.wbaa.airlock.proxy.data._
-import com.ing.wbaa.airlock.proxy.provider.kafka.EventProducer
-import akka.http.scaladsl.model.{ HttpMethod, HttpMethods, RemoteAddress }
 import com.ing.wbaa.airlock.proxy.provider.aws.{ s3ObjectCreated, s3ObjectRemoved }
+import com.ing.wbaa.airlock.proxy.provider.kafka.EventProducer
 
 import scala.concurrent.Future
 
@@ -12,17 +12,17 @@ trait MessageProviderKafka extends EventProducer with AWSMessageEventJsonSupport
 
   private def incompleteData: Future[Nothing] = Future.failed(new Exception("Cannot send event to kafka, not enough input data"))
 
-  def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String, clientIPAddress: RemoteAddress): Future[Done] =
+  def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String): Future[Done] =
     method match {
       case HttpMethods.POST | HttpMethods.PUT =>
-        prepareAWSMessage(s3Request, method, principalId, clientIPAddress, s3ObjectCreated(method.value))
+        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress.get, s3ObjectCreated(method.value))
           .map { case jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.createEventsTopic)
           }
           .getOrElse(incompleteData)
 
       case HttpMethods.DELETE =>
-        prepareAWSMessage(s3Request, method, principalId, clientIPAddress, s3ObjectRemoved(method.value))
+        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress.get, s3ObjectRemoved(method.value))
           .map { case jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.deleteEventsTopic)
           }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafka.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafka.scala
@@ -15,14 +15,14 @@ trait MessageProviderKafka extends EventProducer with AWSMessageEventJsonSupport
   def emitEvent(s3Request: S3Request, method: HttpMethod, principalId: String): Future[Done] =
     method match {
       case HttpMethods.POST | HttpMethods.PUT =>
-        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress.get, s3ObjectCreated(method.value))
+        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress, s3ObjectCreated(method.value))
           .map { case jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.createEventsTopic)
           }
           .getOrElse(incompleteData)
 
       case HttpMethods.DELETE =>
-        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress.get, s3ObjectRemoved(method.value))
+        prepareAWSMessage(s3Request, method, principalId, s3Request.clientIPAddress, s3ObjectRemoved(method.value))
           .map { case jse =>
             sendSingleMessage(jse.toString(), kafkaSettings.deleteEventsTopic)
           }

--- a/src/test/resources/filteredListBucket.xml
+++ b/src/test/resources/filteredListBucket.xml
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>demobucket</Name>
+  <Prefix>user</Prefix>
+  <Marker/>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <EncodingType>url</EncodingType>
+  <Contents>
+    <Key>user1%2Fa%2Fc%2Ftest%2Faala%2Fgg%2Fdfgfg%2F1</Key>
+    <LastModified>2019-02-12T10:21:05.353Z</LastModified>
+    <ETag>"c334e35ed0bd79dfcf1b656c53801d7f"</ETag>
+    <Size>16384</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>testuser</ID>
+      <DisplayName>testuser</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.45</RgwxTag>
+  </Contents>
+  <Contents>
+    <Key>user2</Key>
+    <LastModified>2019-02-12T07:15:17.978Z</LastModified>
+    <ETag>"fcab217e86b7b0bfbb8a6ab4bf713ec5"</ETag>
+    <Size>3638</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>ceph-admin</ID>
+      <DisplayName>Ceph demo user</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.20</RgwxTag>
+  </Contents>
+  <Contents>
+    <Key>user1</Key>
+    <LastModified>2019-02-12T07:15:24.291Z</LastModified>
+    <ETag>"fcab217e86b7b0bfbb8a6ab4bf713ec5"</ETag>
+    <Size>3638</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>ceph-admin</ID>
+      <DisplayName>Ceph demo user</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.21</RgwxTag>
+  </Contents>
+</ListBucketResult>

--- a/src/test/resources/listBucket.xml
+++ b/src/test/resources/listBucket.xml
@@ -1,0 +1,56 @@
+<?xml version='1.0' encoding='UTF-8'?><ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>demobucket</Name>
+  <Prefix>user</Prefix>
+  <Marker/>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <EncodingType>url</EncodingType>
+  <Contents>
+    <Key>user1%2Fa%2Fc%2Ftest%2Faala%2Fgg%2Fdfgfg%2F1</Key>
+    <LastModified>2019-02-12T10:21:05.353Z</LastModified>
+    <ETag>"c334e35ed0bd79dfcf1b656c53801d7f"</ETag>
+    <Size>16384</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>testuser</ID>
+      <DisplayName>testuser</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.45</RgwxTag>
+  </Contents>
+  <Contents>
+    <Key>user2%2Fa%2Fc%2Ftest%2Faala%2Fgg%2Fdfgfg%2F2</Key>
+    <LastModified>2019-02-12T10:21:28.390Z</LastModified>
+    <ETag>"c334e35ed0bd79dfcf1b656c53801d7f"</ETag>
+    <Size>16384</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>testuser</ID>
+      <DisplayName>testuser</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.46</RgwxTag>
+  </Contents>
+  <Contents>
+    <Key>user2</Key>
+    <LastModified>2019-02-12T07:15:17.978Z</LastModified>
+    <ETag>"fcab217e86b7b0bfbb8a6ab4bf713ec5"</ETag>
+    <Size>3638</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>ceph-admin</ID>
+      <DisplayName>Ceph demo user</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.20</RgwxTag>
+  </Contents>
+  <Contents>
+    <Key>user1</Key>
+    <LastModified>2019-02-12T07:15:24.291Z</LastModified>
+    <ETag>"fcab217e86b7b0bfbb8a6ab4bf713ec5"</ETag>
+    <Size>3638</Size>
+    <StorageClass>STANDARD</StorageClass>
+    <Owner>
+      <ID>ceph-admin</ID>
+      <DisplayName>Ceph demo user</DisplayName>
+    </Owner>
+    <RgwxTag>15e78dc1-26ef-45e1-a170-c49693738a71.4110.21</RgwxTag>
+  </Contents>
+</ListBucketResult>

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBucketsSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBucketsSpec.scala
@@ -22,18 +22,18 @@ class ProxyServiceWithListAllBucketsSpec extends FlatSpec with DiagrammedAsserti
 
     implicit def materializer: Materializer = ActorMaterializer()
 
-    override def executeRequest(request: HttpRequest, userSTS: User): Future[HttpResponse] =
+    override def executeRequest(request: HttpRequest, userSTS: User, s3request: S3Request): Future[HttpResponse] =
       Future(HttpResponse(status = StatusCodes.OK))
 
     override def areCredentialsActive(awsRequestCredential: AwsRequestCredential): Future[Option[User]] = Future(
       Some(User(UserName("okUser"), Set(UserGroup("okGroup")), AwsAccessKey("accesskey"), AwsSecretKey("secretkey")))
     )
 
-    override def isUserAuthorizedForRequest(request: S3Request, user: User, clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): Boolean = true
+    override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true
 
     override def isUserAuthenticated(httpRequest: HttpRequest, awsSecretKey: AwsSecretKey): Boolean = true
 
-    override protected[this] def handlePostRequestActions(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request, userSTS: User, clientIPAddress: RemoteAddress): Unit = ()
+    override protected[this] def handlePostRequestActions(response: HttpResponse, httpRequest: HttpRequest, s3Request: S3Request, userSTS: User): Unit = ()
     override protected[this] def listAllBuckets: Seq[String] = List("bucket1", "bucket2")
 
   }
@@ -86,7 +86,7 @@ class ProxyServiceWithListAllBucketsSpec extends FlatSpec with DiagrammedAsserti
 
   it should "return an accessDenied when user is not authorized" in {
     testRequest() ~> new ProxyServiceMock {
-      override def isUserAuthorizedForRequest(request: S3Request, user: User, clientIPAddress: RemoteAddress, headerIPs: HeaderIPs): Boolean = false
+      override def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = false
     }.proxyServiceRoute ~> check {
       assert(status == StatusCodes.Forbidden)
       val response = responseAs[String].replaceAll("\\s", "")

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
@@ -1,6 +1,6 @@
 package com.ing.wbaa.airlock.proxy.data
 
-import akka.http.scaladsl.model.{ HttpMethods, Uri }
+import akka.http.scaladsl.model.{ HttpMethods, RemoteAddress, Uri }
 import org.scalatest.{ DiagrammedAssertions, FlatSpec }
 
 class S3RequestSpec extends FlatSpec with DiagrammedAssertions {
@@ -8,32 +8,32 @@ class S3RequestSpec extends FlatSpec with DiagrammedAssertions {
   val testCred = AwsRequestCredential(AwsAccessKey("ak"), Some(AwsSessionToken("st")))
 
   "S3Request" should "parse an S3 request from an http Path and Method" in {
-    val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.GET)
+    val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, Some("/demobucket"), None, Read))
   }
 
   it should "parse an S3 request from an http Path with object and Method" in {
-    val result = S3Request(testCred, Uri.Path("/demobucket/demoobject"), HttpMethods.GET)
+    val result = S3Request(testCred, Uri.Path("/demobucket/demoobject"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, Some("/demobucket/demoobject"), Some("demoobject"), Read))
   }
 
   it should "parse an S3 request from an http Path with subfolder and Method" in {
-    val result = S3Request(testCred, Uri.Path("/demobucket/subfolder1/"), HttpMethods.GET)
+    val result = S3Request(testCred, Uri.Path("/demobucket/subfolder1/"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, Some("/demobucket/subfolder1/"), None, Read))
   }
 
   it should "parse none for bucket if path is only root" in {
-    val result = S3Request(testCred, Uri.Path("/"), HttpMethods.GET)
+    val result = S3Request(testCred, Uri.Path("/"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, None, None, Read))
   }
 
   it should "parse none for bucket if path is empty" in {
-    val result = S3Request(testCred, Uri.Path(""), HttpMethods.GET)
+    val result = S3Request(testCred, Uri.Path(""), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, None, None, Read))
   }
 
   it should "set access to write for anything but GET" in {
-    val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.POST)
+    val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.POST, RemoteAddress.Unknown, HeaderIPs())
     assert(result == S3Request(testCred, Some("/demobucket"), None, Write))
   }
 

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandlerSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandlerSpec.scala
@@ -1,0 +1,55 @@
+package com.ing.wbaa.airlock.proxy.handler
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{ HttpMethods, RemoteAddress, Uri }
+import akka.stream.scaladsl.{ Sink, Source }
+import akka.stream.{ ActorMaterializer, Materializer }
+import akka.util.ByteString
+import com.ing.wbaa.airlock.proxy.data._
+import org.scalatest.{ AsyncWordSpec, DiagrammedAssertions }
+
+import scala.concurrent.ExecutionContext
+
+class FilterRecursiveListBucketHandlerSpec extends AsyncWordSpec with DiagrammedAssertions with FilterRecursiveListBucketHandler {
+
+  implicit val system: ActorSystem = ActorSystem.create("test-system")
+  override implicit val executionContext: ExecutionContext = system.dispatcher
+
+  implicit def materializer: Materializer = ActorMaterializer()(system)
+
+  def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = {
+    user match {
+      case User(userName, _, _, _) if userName.value == "admin" => true
+      case User(userName, _, _, _) if userName.value == "user1" =>
+        request match {
+          case S3Request(_, s3BucketPath, _, _, _, _) =>
+            if (s3BucketPath.get.startsWith("/demobucket/user/user2")) false else true
+        }
+      case _ => true
+    }
+  }
+
+  val listBucketXmlResponse: String = scala.io.Source.fromResource("listBucket.xml").mkString.stripMargin.trim
+
+  val adminUser = User(UserRawJson("admin", Set.empty[String], "a", "s"))
+  val user1 = User(UserRawJson("user1", Set.empty[String], "a", "s"))
+  val s3Request = S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
+  val data: Source[ByteString, NotUsed] = Source.single(ByteString.fromString(listBucketXmlResponse))
+
+  "List bucket object response" should {
+    "returns all objects to admin" in {
+      data.via(filterRecursiveListObjects(adminUser, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
+        assert(x.mkString.stripMargin.equals(listBucketXmlResponse))
+      })
+    }
+
+    val filteredXml: String = scala.io.Source.fromResource("filteredListBucket.xml").mkString.stripMargin.trim
+    "returns filtered object for user 1" in {
+      data.via(filterRecursiveListObjects(user1, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
+        assert(x.mkString.stripMargin.replaceAll("[\n\r\\s]", "")
+          .equals(filteredXml.replaceAll("[\n\r\\s]", "")))
+      })
+    }
+  }
+}

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
@@ -50,7 +50,7 @@ class RequestHandlerS3Spec extends AsyncWordSpec with DiagrammedAssertions with 
         executeRequest(
           HttpRequest(),
           User(UserRawJson("u", Set.empty[String], "a", "s")),
-          null
+          S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET)
         ).map(_ => assert(numFiredRequests - initialNumFiredRequests == 2))
       }
     }

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
@@ -1,10 +1,13 @@
 package com.ing.wbaa.airlock.proxy.handler
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
+import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.{ ActorMaterializer, Materializer }
+import akka.util.ByteString
 import com.ing.wbaa.airlock.proxy.config.{ AtlasSettings, StorageS3Settings }
-import com.ing.wbaa.airlock.proxy.data.{ User, UserRawJson }
+import com.ing.wbaa.airlock.proxy.data._
 import com.ing.wbaa.airlock.proxy.provider.LineageProviderAtlas
 import org.scalatest.{ AsyncWordSpec, DiagrammedAssertions }
 
@@ -28,15 +31,51 @@ class RequestHandlerS3Spec extends AsyncWordSpec with DiagrammedAssertions with 
 
   override def handleUserCreationRadosGw(userSTS: User): Boolean = true
 
+  def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = {
+    user match {
+      case User(userName, _, _, _) if userName.value == "admin" => true
+      case User(userName, _, _, _) if userName.value == "user1" =>
+        request match {
+          case S3Request(_, s3BucketPath, _, _, _, _) =>
+            if (s3BucketPath.get.startsWith("/demobucket/user/user2")) false else true
+        }
+      case _ => true
+    }
+  }
+
   "Request Handler" should {
     "execute a request" that {
       "retries a request when forbidden and user needs to be created" in {
         val initialNumFiredRequests = numFiredRequests
         executeRequest(
           HttpRequest(),
-          User(UserRawJson("u", Set.empty[String], "a", "s"))
+          User(UserRawJson("u", Set.empty[String], "a", "s")),
+          null
         ).map(_ => assert(numFiredRequests - initialNumFiredRequests == 2))
       }
+    }
+  }
+
+  val listBucketXmlResponse: String = scala.io.Source.fromResource("listBucket.xml").mkString.stripMargin.trim
+
+  val adminUser = User(UserRawJson("admin", Set.empty[String], "a", "s"))
+  val user1 = User(UserRawJson("user1", Set.empty[String], "a", "s"))
+  val s3Request = S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET)
+  val data: Source[ByteString, NotUsed] = Source.single(ByteString.fromString(listBucketXmlResponse))
+
+  "List bucket object response" should {
+    "returns all objects to admin" in {
+      data.via(filterRecursiveListObjects(adminUser, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
+        assert(x.mkString.stripMargin.equals(listBucketXmlResponse))
+      })
+    }
+
+    val filteredXml: String = scala.io.Source.fromResource("filteredListBucket.xml").mkString.stripMargin.trim
+    "returns filtered object for user 1" in {
+      data.via(filterRecursiveListObjects(user1, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
+        assert(x.mkString.stripMargin.replaceAll("[\n\r\\s]", "")
+          .equals(filteredXml.replaceAll("[\n\r\\s]", "")))
+      })
     }
   }
 }

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/handler/RequestHandlerS3Spec.scala
@@ -1,11 +1,8 @@
 package com.ing.wbaa.airlock.proxy.handler
 
-import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.{ ActorMaterializer, Materializer }
-import akka.util.ByteString
 import com.ing.wbaa.airlock.proxy.config.{ AtlasSettings, StorageS3Settings }
 import com.ing.wbaa.airlock.proxy.data._
 import com.ing.wbaa.airlock.proxy.provider.LineageProviderAtlas
@@ -20,10 +17,13 @@ class RequestHandlerS3Spec extends AsyncWordSpec with DiagrammedAssertions with 
   override val storageS3Settings: StorageS3Settings = new StorageS3Settings(system.settings.config) {
     override val storageS3Authority: Uri.Authority = Uri.Authority(Uri.Host("1.2.3.4"), 1234)
   }
+
   override implicit def materializer: Materializer = ActorMaterializer()(system)
+
   override val atlasSettings: AtlasSettings = new AtlasSettings(system.settings.config)
 
   var numFiredRequests = 0
+
   override def fireRequestToS3(request: HttpRequest): Future[HttpResponse] = {
     numFiredRequests = numFiredRequests + 1
     Future.successful(HttpResponse(status = StatusCodes.Forbidden))
@@ -31,17 +31,9 @@ class RequestHandlerS3Spec extends AsyncWordSpec with DiagrammedAssertions with 
 
   override def handleUserCreationRadosGw(userSTS: User): Boolean = true
 
-  def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = {
-    user match {
-      case User(userName, _, _, _) if userName.value == "admin" => true
-      case User(userName, _, _, _) if userName.value == "user1" =>
-        request match {
-          case S3Request(_, s3BucketPath, _, _, _, _) =>
-            if (s3BucketPath.get.startsWith("/demobucket/user/user2")) false else true
-        }
-      case _ => true
-    }
-  }
+  def isUserAuthorizedForRequest(request: S3Request, user: User): Boolean = true
+
+  override protected def filterResponse(request: HttpRequest, userSTS: User, s3request: S3Request, response: HttpResponse): HttpResponse = null
 
   "Request Handler" should {
     "execute a request" that {
@@ -50,32 +42,10 @@ class RequestHandlerS3Spec extends AsyncWordSpec with DiagrammedAssertions with 
         executeRequest(
           HttpRequest(),
           User(UserRawJson("u", Set.empty[String], "a", "s")),
-          S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET)
+          S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs())
         ).map(_ => assert(numFiredRequests - initialNumFiredRequests == 2))
       }
     }
   }
 
-  val listBucketXmlResponse: String = scala.io.Source.fromResource("listBucket.xml").mkString.stripMargin.trim
-
-  val adminUser = User(UserRawJson("admin", Set.empty[String], "a", "s"))
-  val user1 = User(UserRawJson("user1", Set.empty[String], "a", "s"))
-  val s3Request = S3Request(AwsRequestCredential(AwsAccessKey(""), None), Uri.Path("/demobucket/user"), HttpMethods.GET)
-  val data: Source[ByteString, NotUsed] = Source.single(ByteString.fromString(listBucketXmlResponse))
-
-  "List bucket object response" should {
-    "returns all objects to admin" in {
-      data.via(filterRecursiveListObjects(adminUser, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
-        assert(x.mkString.stripMargin.equals(listBucketXmlResponse))
-      })
-    }
-
-    val filteredXml: String = scala.io.Source.fromResource("filteredListBucket.xml").mkString.stripMargin.trim
-    "returns filtered object for user 1" in {
-      data.via(filterRecursiveListObjects(user1, s3Request)).map(_.utf8String).runWith(Sink.seq).map(x => {
-        assert(x.mkString.stripMargin.replaceAll("[\n\r\\s]", "")
-          .equals(filteredXml.replaceAll("[\n\r\\s]", "")))
-      })
-    }
-  }
 }


### PR DESCRIPTION
For the recursive list bucket - currently there is checked only the root resource in ranger so it is posible to see all subdirs. The fix checks in ranger all subdirs.