### PR TITLE
Revert "Merge pull request #51 from ing-bank/remove-system-flag"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.packager.docker.ExecCmd
 import scalariform.formatter.preferences._
 
 name := "airlock"
-version := "0.1.15"
+version := "0.1.13"
 
 scalaVersion := "2.12.8"
 

--- a/setupS3Env.sh
+++ b/setupS3Env.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-
-docker cp src/main/resources/default-bucket-policy.json $(docker-compose ps -q ceph):/root
 docker-compose exec ceph radosgw-admin user modify --uid ceph-admin --system
-docker-compose exec ceph s3cmd setpolicy /root/default-bucket-policy.json s3://demobucket
 docker-compose exec ceph s3cmd put /etc/issue s3://demobucket/subdir/
 docker-compose exec ceph s3cmd mb s3://home
 docker-compose exec ceph s3cmd put /etc/issue s3://home/testuser/

--- a/src/it/scala/com/ing/wbaa/testkit/AirlockFixtures.scala
+++ b/src/it/scala/com/ing/wbaa/testkit/AirlockFixtures.scala
@@ -59,8 +59,6 @@ trait AirlockFixtures extends S3SdkHelpers {
   def withHomeBucket(s3Client: AmazonS3, objects: Seq[String])(testCode: String => Future[Assertion])(implicit exCtx: ExecutionContext): Future[Assertion] = {
     val testBucket = "home"
     Try(s3Client.createBucket(testBucket))
-    // Leave some time to set bucket policy asynchronously
-    Thread.sleep(5000)
     objects.foreach(obj => s3Client.putObject(testBucket, obj, ""))
     testCode(testBucket).andThen {
       case _ =>

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/radosgw/RadosGatewayHandler.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/radosgw/RadosGatewayHandler.scala
@@ -36,7 +36,8 @@ trait RadosGatewayHandler extends LazyLogging {
         Map(
           "display-name" -> userName.value,
           "access-key" -> awsAccessKey.value,
-          "secret-key" -> awsSecretKey.value
+          "secret-key" -> awsSecretKey.value,
+          "system" -> "true"
         ).asJava
       )
     } match {


### PR DESCRIPTION
This reverts commit ba3ccfb3152ee59155c3c1cddf9604b93f974ca9, reversing changes made to 3fe9d14f5573642ac7d6450c142c31cf7c1ae431.

The system flag must be preserved to maintain compatibility with Spark.
Hadoop writes are otherwise failing due to status code 403 returned by
Radosgw when doing HeadObject on non existing objects.