### PR TITLE
add a ranger action name for audit

### DIFF
--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/AuthorizationProviderRangerItTest.scala
@@ -19,7 +19,7 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
     AwsRequestCredential(AwsAccessKey("accesskey"), Some(AwsSessionToken("sessiontoken"))),
     Some("/demobucket"),
     None,
-    Read
+    Read()
   )
 
   val user = User(
@@ -72,7 +72,7 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       }
 
       "doesn't authorize for requests that are not supposed to be (Write)" in withAuthorizationProviderRanger() { apr =>
-        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write, s3Object = Some("object"),
+        assert(!apr.isUserAuthorizedForRequest(s3Request.copy(accessType = Write(), s3Object = Some("object"),
           clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
@@ -94,27 +94,27 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
 
       "authorize allow-list-buckets with default settings" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None,
-          accessType = Read, clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
+          accessType = Read(), clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize allow-list-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val listBucketsEnabled: Boolean = true
       }) { apr =>
         assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = None, s3Object = None,
-          accessType = Read, clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
+          accessType = Read(), clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize allow-create-buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Write,
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Write(),
           clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
       "does authorize delete buckets set to true" in withAuthorizationProviderRanger(new RangerSettings(testSystem.settings.config) {
         override val createBucketsEnabled: Boolean = true
       }) { apr =>
-        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Delete,
+        assert(apr.isUserAuthorizedForRequest(s3Request.copy(s3Object = None, accessType = Delete(),
           clientIPAddress = clientIPAddress, headerIPs = headerIPs), user))
       }
 
@@ -167,14 +167,14 @@ class AuthorizationProviderRangerItTest extends AsyncWordSpec with DiagrammedAss
       "does allow write homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(apr.isUserAuthorizedForRequest(
           s3Request.copy(s3BucketPath = Some("/home/testuser"), s3Object = Some("object1"),
-            accessType = Write, clientIPAddress = clientIPAddress,
+            accessType = Write(), clientIPAddress = clientIPAddress,
             headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 
       "doesn't allow write in non homedir in the bucket" in withAuthorizationProviderRanger() { apr =>
         assert(!apr.isUserAuthorizedForRequest(
           s3Request.copy(s3BucketPath = Some("/home/testuser1"), s3Object = Some("object1"),
-            accessType = Write, clientIPAddress = clientIPAddress,
+            accessType = Write(), clientIPAddress = clientIPAddress,
             headerIPs = headerIPs.copy(`Remote-Address` = Some(RemoteAddress.Unknown))), user))
       }
 

--- a/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
+++ b/src/it/scala/com/ing/wbaa/airlock/proxy/provider/MessageProviderKafkaItTest.scala
@@ -25,7 +25,7 @@ class MessageProviderKafkaItTest extends WordSpecLike with DiagrammedAssertions 
 
   implicit val requestId: RequestId = RequestId("test")
 
-  val s3Request = S3Request(AwsRequestCredential(AwsAccessKey("a"), None), Some("demobucket"), Some("s3object"), Read)
+  val s3Request = S3Request(AwsRequestCredential(AwsAccessKey("a"), None), Some("demobucket"), Some("s3object"), Read())
     .copy(clientIPAddress = RemoteAddress(InetAddress.getByName("127.0.0.1")))
 
   "KafkaMessageProvider" should {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyService.scala
@@ -79,7 +79,7 @@ trait ProxyService {
         isUserAuthorizedForRequest(s3Request.copy(s3BucketPath = Some(s"$bucket/$s3Object"), s3Object = Some(s3Object)), userSTS)
       }
     }.map { permittedObjects =>
-      if (permittedObjects.length > 0 && permittedObjects.contains(false)) {
+      if (permittedObjects.nonEmpty && permittedObjects.contains(false)) {
         logger.debug("An error occurred, one of objects not allowed to be accessed")
         complete(StatusCodes.Forbidden -> AwsErrorCodes.response(StatusCodes.Forbidden))
       } else {
@@ -110,7 +110,7 @@ trait ProxyService {
         if (isMultideletePost) {
           checkExtractedPostContents(
             httpRequest,
-            s3Request.copy(mediaType = MediaTypes.`application/xml`), userSTS)
+            s3Request.copy(mediaType = MediaTypes.`application/xml`, accessType = Write("MULTIDELETE POST")), userSTS)
         } else {
           logger.info(s"User (${userSTS.userName}) successfully authorized for request: $s3Request")
           Future(processAuthorizedRequest(httpRequest, s3Request, userSTS))

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBuckets.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/api/ProxyServiceWithListAllBuckets.scala
@@ -20,7 +20,7 @@ trait ProxyServiceWithListAllBuckets extends ProxyService with ScalaXmlSupport {
   override protected[this] def processAuthorizedRequest(httpRequest: HttpRequest, s3Request: S3Request, userSTS: User)(implicit id: RequestId): Route = {
     s3Request match {
       //only when list buckets is requested we show all buckets
-      case S3Request(_, None, None, accessType, _, _, _) if accessType == Read =>
+      case S3Request(_, None, None, accessType, _, _, _) if accessType.isInstanceOf[Read] =>
         complete(getListAllMyBucketsXml())
       case _ => super.processAuthorizedRequest(httpRequest, s3Request, userSTS)
     }

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/AccessType.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/AccessType.scala
@@ -1,9 +1,10 @@
 package com.ing.wbaa.airlock.proxy.data
 
-sealed class AccessType(val rangerName: String)
+sealed class AccessType(val rangerName: String, val auditAction: String)
 
-case object Read extends AccessType("read")
-case object Head extends AccessType("read")
-case object Write extends AccessType("write")
-case object Delete extends AccessType("write")
-case object NoAccess extends AccessType("noAccess")
+case class Read(override val auditAction: String = "") extends AccessType("read", auditAction)
+case class Head(override val auditAction: String = "") extends AccessType("read", auditAction)
+case class Write(override val auditAction: String = "") extends AccessType("write", auditAction)
+case class Delete(override val auditAction: String = "") extends AccessType("write", auditAction)
+case object NoAccess extends AccessType("noAccess", "noAccess")
+

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/data/S3Request.scala
@@ -38,11 +38,11 @@ object S3Request extends LazyLogging {
     val s3Object = extractObject(pathString)
 
     val accessType = httpMethod.value match {
-      case "GET"    => Read
-      case "HEAD"   => Head
-      case "PUT"    => Write
-      case "POST"   => Write
-      case "DELETE" => Delete
+      case "GET"    => Read(httpMethod.value)
+      case "HEAD"   => Head(httpMethod.value)
+      case "PUT"    => Write(httpMethod.value)
+      case "POST"   => Write(httpMethod.value)
+      case "DELETE" => Delete(httpMethod.value)
       case _ =>
         logger.debug("HttpMethod not supported")
         NoAccess

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandler.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/handler/FilterRecursiveListBucketHandler.scala
@@ -35,7 +35,7 @@ trait FilterRecursiveListBucketHandler {
    */
   protected[this] def filterResponse(request: HttpRequest, userSTS: User, s3request: S3Request, response: HttpResponse)(implicit id: RequestId): HttpResponse = {
     val noDelimiterWithReadAndNoObject =
-      !request.uri.rawQueryString.getOrElse("").contains("delimiter") && s3request.accessType == Read && s3request.s3Object.isEmpty
+      !request.uri.rawQueryString.getOrElse("").contains("delimiter") && s3request.accessType.isInstanceOf[Read] && s3request.s3Object.isEmpty
     if (noDelimiterWithReadAndNoObject) {
       response.transformEntityDataBytes(filterRecursiveListObjects(userSTS, s3request))
     } else {

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/LineageProviderAtlas.scala
@@ -27,20 +27,20 @@ trait LineageProviderAtlas extends RestClient with LineageHelpers {
         // get object
         case HttpMethods.GET if lineageHeaders.queryParams.isEmpty || lineageHeaders.queryParams.contains("encoding-type") =>
           val externalObject = s"$EXTERNAL_OBJECT_OUT/${bucketObject.split("/").takeRight(1).mkString}"
-          readOrWriteLineage(lineageHeaders, userSTS, Read, clientIPAddress, Some(externalObject))
+          readOrWriteLineage(lineageHeaders, userSTS, Read(), clientIPAddress, Some(externalObject))
 
         // put object from outside of ceph
         case HttpMethods.PUT if lineageHeaders.queryParams.isEmpty && lineageHeaders.copySource.isEmpty =>
           val externalObject = s"$EXTERNAL_OBJECT_IN/${bucketObject.split("/").takeRight(1).mkString}"
-          readOrWriteLineage(lineageHeaders, userSTS, Write, clientIPAddress, Some(externalObject))
+          readOrWriteLineage(lineageHeaders, userSTS, Write(), clientIPAddress, Some(externalObject))
 
         // put object - copy
         // if contains header x-amz-copy-source
-        case HttpMethods.PUT if lineageHeaders.copySource.getOrElse("").length > 0 => lineageForCopyOperation(lineageHeaders, userSTS, Write, clientIPAddress)
+        case HttpMethods.PUT if lineageHeaders.copySource.getOrElse("").length > 0 => lineageForCopyOperation(lineageHeaders, userSTS, Write(), clientIPAddress)
 
         // post object (complete multipart)
         // aws request eg. POST /ObjectName?uploadId=UploadId and content-type application/xml
-        case HttpMethods.POST if lineageHeaders.queryParams.getOrElse("").contains("uploadId") => readOrWriteLineage(lineageHeaders, userSTS, Write, clientIPAddress)
+        case HttpMethods.POST if lineageHeaders.queryParams.getOrElse("").contains("uploadId") => readOrWriteLineage(lineageHeaders, userSTS, Write(), clientIPAddress)
 
         // delete object
         case HttpMethods.DELETE if lineageHeaders.queryParams.isEmpty => deleteLineage(lineageHeaders)

--- a/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
+++ b/src/main/scala/com/ing/wbaa/airlock/proxy/provider/atlas/LineageHelpers.scala
@@ -155,21 +155,21 @@ trait LineageHelpers extends LazyLogging with RestClient {
         case None         => Future.successful("")
       }
       processGuid <- method match {
-        case Read =>
+        case Read(_) =>
           postData(
             processEntities(
               serverGuid, bucketGuid, objectGuid, userName, method.rangerName, processIn(objectGuid, AWS_S3_OBJECT_TYPE), processOut(fsPathGuid, HADOOP_FS_PATH), clientType, timestamp
             ).toJson)
             .map(r => r.entityGUID)
 
-        case Write if fsPathGuid.length > 0 =>
+        case Write(_) if fsPathGuid.length > 0 =>
           postData(
             processEntities(
               serverGuid, bucketGuid, objectGuid, userName, method.rangerName, processIn(fsPathGuid, HADOOP_FS_PATH), processOut(objectGuid, AWS_S3_OBJECT_TYPE), clientType, timestamp
             ).toJson)
             .map(r => r.entityGUID)
 
-        case Write =>
+        case Write(_) =>
           postData(
             processEntities(
               serverGuid, bucketGuid, objectGuid, userName, method.rangerName, processIn(objectGuid, AWS_S3_OBJECT_TYPE), processOut(pseudoDirGuid, AWS_S3_PSEUDO_DIR_TYPE), clientType, timestamp

--- a/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
+++ b/src/test/scala/com/ing/wbaa/airlock/proxy/data/S3RequestSpec.scala
@@ -9,32 +9,32 @@ class S3RequestSpec extends FlatSpec with DiagrammedAssertions {
 
   "S3Request" should "parse an S3 request from an http Path and Method" in {
     val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, Some("/demobucket"), None, Read))
+    assert(result == S3Request(testCred, Some("/demobucket"), None, Read("GET")))
   }
 
   it should "parse an S3 request from an http Path with object and Method" in {
     val result = S3Request(testCred, Uri.Path("/demobucket/demoobject"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, Some("/demobucket/demoobject"), Some("demoobject"), Read))
+    assert(result == S3Request(testCred, Some("/demobucket/demoobject"), Some("demoobject"), Read("GET")))
   }
 
   it should "parse an S3 request from an http Path with subfolder and Method" in {
     val result = S3Request(testCred, Uri.Path("/demobucket/subfolder1/"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, Some("/demobucket/subfolder1/"), None, Read))
+    assert(result == S3Request(testCred, Some("/demobucket/subfolder1/"), None, Read("GET")))
   }
 
   it should "parse none for bucket if path is only root" in {
     val result = S3Request(testCred, Uri.Path("/"), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, None, None, Read))
+    assert(result == S3Request(testCred, None, None, Read("GET")))
   }
 
   it should "parse none for bucket if path is empty" in {
     val result = S3Request(testCred, Uri.Path(""), HttpMethods.GET, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, None, None, Read))
+    assert(result == S3Request(testCred, None, None, Read("GET")))
   }
 
   it should "set access to write for anything but GET" in {
     val result = S3Request(testCred, Uri.Path("/demobucket"), HttpMethods.POST, RemoteAddress.Unknown, HeaderIPs(), MediaTypes.`text/plain`)
-    assert(result == S3Request(testCred, Some("/demobucket"), None, Write))
+    assert(result == S3Request(testCred, Some("/demobucket"), None, Write("POST")))
   }
 
 }


### PR DESCRIPTION
 * range audit uses `action` field to set accessType in the log
 * we have `read` and `write` access types but in range there will be a http method names in the log + extra `multidelete post` 